### PR TITLE
Seed subscriptions with database connection error

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,18 @@
 version: '3.8'
 
 services:
+  mongodb:
+    image: mongo:7.0
+    ports:
+      - "27017:27017"
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: admin
+      MONGO_INITDB_ROOT_PASSWORD: password
+      MONGO_INITDB_DATABASE: urban-realty
+    volumes:
+      - mongodb_data:/data/db
+    restart: unless-stopped
+
   app:
     build:
       context: .
@@ -14,3 +26,8 @@ services:
     volumes:
       - ./server/uploads:/app/uploads
     restart: unless-stopped
+    depends_on:
+      - mongodb
+
+volumes:
+  mongodb_data:


### PR DESCRIPTION
Add MongoDB service to `docker-compose.yml` to enable running the database via Docker.

This change allows the application to connect to a MongoDB instance, resolving the `ECONNREFUSED` error encountered when running the `seedSubscriptions.js` script.

---
<a href="https://cursor.com/background-agent?bcId=bc-2f2b8731-6ca3-44dd-aa40-0270d2555c07">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2f2b8731-6ca3-44dd-aa40-0270d2555c07">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

