### PR TITLE
Fix subscription api 404 error

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -23,10 +23,10 @@ setTimeout(async () => {
 
 // Configure paths
 const uploadsDir = path.join(__dirname, 'uploads');
-const clientDistDir = path.join('/app/client/dist'); // Updated path
+const clientDistDir = path.join(__dirname, '..', 'client', 'dist'); // Updated path
 
 // Create directories
-[uploadsDir, clientDistDir].forEach(dir => {
+[uploadsDir].forEach(dir => {
   try {
     if (!fs.existsSync(dir)) {
       fs.mkdirSync(dir, { recursive: true });
@@ -37,6 +37,16 @@ const clientDistDir = path.join('/app/client/dist'); // Updated path
     process.exit(1);
   }
 });
+
+// Create client dist directory if it doesn't exist (optional)
+try {
+  if (!fs.existsSync(clientDistDir)) {
+    fs.mkdirSync(clientDistDir, { recursive: true });
+    console.log(`Directory created: ${clientDistDir}`);
+  }
+} catch (err) {
+  console.warn(`Warning: Could not create client dist directory ${clientDistDir}:`, err.message);
+}
 
 // Middleware
 app.use(cors({


### PR DESCRIPTION
Fix 404 error by correcting the client dist path and making its directory creation optional.

The server was failing to start due to a hardcoded path `/app/client/dist` that did not exist in the environment, leading to a 404 for all API requests. This change updates the path to be relative and allows the server to start even if the client build directory is not yet present.

---
<a href="https://cursor.com/background-agent?bcId=bc-86f20b68-2da0-40bd-ab99-901a4288d28f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-86f20b68-2da0-40bd-ab99-901a4288d28f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

