### PR TITLE
Debug and fix application errors

### DIFF
--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -14,7 +14,8 @@ const queryClient = new QueryClient({
       retry: 1,
       refetchOnWindowFocus: false,
       staleTime: 5 * 60 * 1000, // 5 minutes
-      cacheTime: 10 * 60 * 1000, // 10 minutes
+      // react-query v5 renamed cacheTime -> gcTime
+      gcTime: 10 * 60 * 1000, // 10 minutes
     },
   },
 });

--- a/client/src/services/axios.js
+++ b/client/src/services/axios.js
@@ -1,8 +1,13 @@
 import axios from 'axios';
 
+const baseURL =
+  import.meta?.env?.VITE_API_BASE_URL?.replace(/\/$/, '') ||
+  (typeof window !== 'undefined' && window.__API_BASE_URL__
+    ? String(window.__API_BASE_URL__).replace(/\/$/, '')
+    : 'https://urban-realty-production.up.railway.app');
+
 const instance = axios.create({
-  baseURL: 'https://urban-realty-production.up.railway.app/api/v1',
-  //baseURL: 'http://localhost:5000/api/v1',
+  baseURL: `${baseURL}/api/v1`,
   timeout: 30000,
   headers: {
     'Content-Type': 'application/json',


### PR DESCRIPTION
Update React Query v5 configuration and make Axios base URL configurable to fix `defaultQueryOptions` TypeError and improve API endpoint flexibility.

The `defaultQueryOptions` error was a `TypeError` caused by a breaking change in React Query v5, where `cacheTime` was renamed to `gcTime`. Making the Axios base URL configurable via `VITE_API_BASE_URL` addresses potential 404/500 errors by allowing the API endpoint to be dynamically set, which is crucial for different deployment environments.

---
<a href="https://cursor.com/background-agent?bcId=bc-9cc79e93-7ebd-4fd3-9ee3-ed40e111b81d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9cc79e93-7ebd-4fd3-9ee3-ed40e111b81d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

