### PR TITLE
Fix card theme type mismatch in app theme

### DIFF
--- a/mobile/lib/config/app_theme.dart
+++ b/mobile/lib/config/app_theme.dart
@@ -83,7 +83,7 @@ class AppTheme {
     ),
     
     // Card Theme
-    cardTheme: CardTheme(
+    cardTheme: CardThemeData(
       elevation: 2,
       shadowColor: const Color(0xFF000000).withOpacity(0.1),
       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
@@ -216,7 +216,7 @@ class AppTheme {
     ),
     
     // Card Theme
-    cardTheme: CardTheme(
+    cardTheme: CardThemeData(
       elevation: 4,
       shadowColor: const Color(0xFF000000).withOpacity(0.3),
       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),


### PR DESCRIPTION
Update `CardTheme` to `CardThemeData` to resolve a compilation error in newer Flutter versions.

The `CardTheme` class has been replaced by `CardThemeData` in recent Flutter updates, leading to a type mismatch error during compilation. This change updates the theme configuration to use the correct class.

---
<a href="https://cursor.com/background-agent?bcId=bc-b8dbb0d1-c788-47ff-b106-29f002740cd8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b8dbb0d1-c788-47ff-b106-29f002740cd8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

