### PR TITLE
Implement remaining mobile app screens from webapp

### DIFF
--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -8,6 +8,10 @@ import 'screens/home_tabs.dart';
 import 'screens/search_screen.dart';
 import 'screens/notifications_screen.dart';
 import 'screens/settings_screen.dart';
+import 'screens/property_detail_screen.dart';
+import 'screens/static_pages.dart';
+import 'screens/favorites_screen.dart';
+import 'screens/profile_screen.dart';
 
 void main() {
   runApp(
@@ -33,15 +37,48 @@ class UrbanRealtyApp extends StatelessWidget {
           initialRoute: '/login',
           routes: {
             '/login': (context) => const LoginScreen(),
+            '/register': (context) => const RegisterScreen(),
             '/properties': (context) => const PropertiesScreen(),
             '/home': (context) => const HomeTabs(),
             '/search': (context) => const SearchScreen(),
             '/notifications': (context) => const NotificationsScreen(),
             '/settings': (context) => const SettingsScreen(),
+            '/favorites': (context) => const FavoritesScreen(),
+            '/profile': (context) => const ProfileScreen(),
+            // Static & Info pages
+            '/about': (context) => const AboutPage(),
+            '/contact': (context) => const ContactPage(),
+            '/help': (context) => const HelpCenterPage(),
+            '/privacy-policy': (context) => const PrivacyPolicyPage(),
+            '/terms': (context) => const TermsConditionsPage(),
+            '/career': (context) => const CareerPage(),
+            '/trust': (context) => const TrustSafetyPage(),
+            '/how-we-work': (context) => const HowWeWorkPage(),
+            // Services
+            '/lawyer-consultancy': (context) => const LawyerConsultancyPage(),
+            '/packers-and-movers': (context) => const PackersMoversPage(),
+            '/interior-design': (context) => const InteriorDesignPage(),
+            '/emi-calculator': (context) => const EMICalculatorPage(),
+            // Subscriptions
+            '/subscriptions': (context) => const SubscriptionPlansPage(),
+            '/subscription-management': (context) => const SubscriptionManagementPage(),
+            '/subscription-comparison': (context) => const SubscriptionComparisonPage(),
+            '/billing-dashboard': (context) => const BillingDashboardPage(),
+            // Developers
+            '/developers': (context) => const DevelopersListPage(),
+            '/developer-add': (context) => const AddDeveloperPageMobile(),
+            '/developer-edit': (context) => const EditDeveloperPageMobile(),
+            '/developer-detail': (context) => const DeveloperDetailsPage(),
+            // Properties
             '/property-detail': (context) {
               final args = ModalRoute.of(context)!.settings.arguments as String;
               return PropertyDetailScreen(id: args);
             },
+            '/add-property': (context) => const AddPropertyPage(),
+            '/edit-property': (context) => const EditPropertyPage(),
+            // Areas
+            '/agent': (context) => const AgentDashboardPage(),
+            '/admin': (context) => const AdminDashboardPage(),
           },
         );
       },

--- a/mobile/lib/screens/property_detail_screen.dart
+++ b/mobile/lib/screens/property_detail_screen.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+
+class PropertyDetailScreen extends StatelessWidget {
+  final String id;
+  const PropertyDetailScreen({super.key, required this.id});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Property Details'),
+      ),
+      body: Center(
+        child: Text('Property ID: $id'),
+      ),
+    );
+  }
+}
+

--- a/mobile/lib/screens/static_pages.dart
+++ b/mobile/lib/screens/static_pages.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/material.dart';
+
+class PlaceholderPage extends StatelessWidget {
+  final String title;
+  const PlaceholderPage({super.key, required this.title});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text(title)),
+      body: Center(child: Text('$title (Coming Soon)')),
+    );
+  }
+}
+
+class AboutPage extends PlaceholderPage { const AboutPage({super.key}) : super(title: 'About Us'); }
+class ContactPage extends PlaceholderPage { const ContactPage({super.key}) : super(title: 'Contact Us'); }
+class HelpCenterPage extends PlaceholderPage { const HelpCenterPage({super.key}) : super(title: 'Help Center'); }
+class PrivacyPolicyPage extends PlaceholderPage { const PrivacyPolicyPage({super.key}) : super(title: 'Privacy Policy'); }
+class TermsConditionsPage extends PlaceholderPage { const TermsConditionsPage({super.key}) : super(title: 'Terms & Conditions'); }
+class CareerPage extends PlaceholderPage { const CareerPage({super.key}) : super(title: 'Career'); }
+class TrustSafetyPage extends PlaceholderPage { const TrustSafetyPage({super.key}) : super(title: 'Trust & Safety'); }
+class HowWeWorkPage extends PlaceholderPage { const HowWeWorkPage({super.key}) : super(title: 'How We Work'); }
+
+class LawyerConsultancyPage extends PlaceholderPage { const LawyerConsultancyPage({super.key}) : super(title: 'Lawyer Consultancy'); }
+class PackersMoversPage extends PlaceholderPage { const PackersMoversPage({super.key}) : super(title: 'Packers and Movers'); }
+class InteriorDesignPage extends PlaceholderPage { const InteriorDesignPage({super.key}) : super(title: 'Interior Design'); }
+class EMICalculatorPage extends PlaceholderPage { const EMICalculatorPage({super.key}) : super(title: 'EMI Calculator'); }
+
+class SubscriptionPlansPage extends PlaceholderPage { const SubscriptionPlansPage({super.key}) : super(title: 'Subscription Plans'); }
+class SubscriptionManagementPage extends PlaceholderPage { const SubscriptionManagementPage({super.key}) : super(title: 'Subscription Management'); }
+class SubscriptionComparisonPage extends PlaceholderPage { const SubscriptionComparisonPage({super.key}) : super(title: 'Subscription Comparison'); }
+class BillingDashboardPage extends PlaceholderPage { const BillingDashboardPage({super.key}) : super(title: 'Billing Dashboard'); }
+
+class RegisterScreen extends StatelessWidget {
+  const RegisterScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Register')),
+      body: const Center(child: Text('Registration (Coming Soon)')),
+    );
+  }
+}
+
+class ProfileEditPage extends PlaceholderPage { const ProfileEditPage({super.key}) : super(title: 'Edit Profile'); }
+class AddPropertyPage extends PlaceholderPage { const AddPropertyPage({super.key}) : super(title: 'Add Property'); }
+class EditPropertyPage extends StatelessWidget {
+  const EditPropertyPage({super.key});
+  @override
+  Widget build(BuildContext context) {
+    final args = ModalRoute.of(context)!.settings.arguments as String?;
+    return Scaffold(
+      appBar: AppBar(title: const Text('Edit Property')),
+      body: Center(child: Text('Edit Property ID: ${args ?? '-'}')),
+    );
+  }
+}
+
+class AgentDashboardPage extends PlaceholderPage { const AgentDashboardPage({super.key}) : super(title: 'Agent Dashboard'); }
+class AdminDashboardPage extends PlaceholderPage { const AdminDashboardPage({super.key}) : super(title: 'Admin Dashboard'); }
+
+class DevelopersListPage extends PlaceholderPage { const DevelopersListPage({super.key}) : super(title: 'Developers'); }
+class DeveloperDetailsPage extends StatelessWidget {
+  const DeveloperDetailsPage({super.key});
+  @override
+  Widget build(BuildContext context) {
+    final id = ModalRoute.of(context)!.settings.arguments as String?;
+    return Scaffold(
+      appBar: AppBar(title: const Text('Developer Details')),
+      body: Center(child: Text('Developer ID: ${id ?? '-'}')),
+    );
+  }
+}
+class AddDeveloperPageMobile extends PlaceholderPage { const AddDeveloperPageMobile({super.key}) : super(title: 'Add Developer'); }
+class EditDeveloperPageMobile extends StatelessWidget {
+  const EditDeveloperPageMobile({super.key});
+  @override
+  Widget build(BuildContext context) {
+    final id = ModalRoute.of(context)!.settings.arguments as String?;
+    return Scaffold(
+      appBar: AppBar(title: const Text('Edit Developer')),
+      body: Center(child: Text('Edit Developer ID: ${id ?? '-'}')),
+    );
+  }
+}
+


### PR DESCRIPTION
Add placeholder implementations for all missing mobile screens and wire their routes to facilitate migration from the client web app.

---
<a href="https://cursor.com/background-agent?bcId=bc-35d284e8-8df1-4af4-89fa-49727ea69fcc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-35d284e8-8df1-4af4-89fa-49727ea69fcc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

