### PR TITLE
Fix flutter local notifications compilation errors

### DIFF
--- a/mobile/android/app/build.gradle.kts
+++ b/mobile/android/app/build.gradle.kts
@@ -11,13 +11,13 @@ android {
     ndkVersion = flutter.ndkVersion
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
         isCoreLibraryDesugaringEnabled = true
     }
 
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_11.toString()
+        jvmTarget = JavaVersion.VERSION_17.toString()
     }
 
     defaultConfig {

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -32,7 +32,7 @@ dependencies:
   firebase_core: ^2.24.2
   webview_flutter: ^4.4.2
   razorpay_flutter: ^1.3.5
-  flutter_local_notifications: ^16.3.0
+  flutter_local_notifications: ^17.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Update `flutter_local_notifications` and Java compatibility to resolve compilation errors and obsolete Java warnings.

The `flutter_local_notifications` plugin (v16.3.0) caused an ambiguous method call error (`bigLargeIcon(null)`) when compiled with newer Android SDK versions due to conflicting method overloads. Updating the plugin to v17.0.0 resolves this, and updating Java compatibility addresses warnings about obsolete Java 8.

---
<a href="https://cursor.com/background-agent?bcId=bc-774ddbad-c044-428e-a69f-ef414aab445a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-774ddbad-c044-428e-a69f-ef414aab445a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

