### PR TITLE
Fix static access and http client errors

### DIFF
--- a/mobile/lib/screens/login_screen.dart
+++ b/mobile/lib/screens/login_screen.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import '../services/auth_service.dart';
 import '../providers/auth_provider.dart';
 
 class LoginScreen extends StatefulWidget {

--- a/mobile/lib/services/http_client.dart
+++ b/mobile/lib/services/http_client.dart
@@ -2,7 +2,7 @@ import 'dart:convert';
 import 'package:http/http.dart' as http;
 
 class HttpClient {
-  static const String baseUrl = 'https://urban-realty-production.up.railway.app/api/v1',
+  static const String baseUrl = 'https://urban-realty-production.up.railway.app/api/v1';
   
   static Future<http.Response> get(String endpoint, {Map<String, String>? query, Map<String, String>? headers}) async {
     try {


### PR DESCRIPTION
Fix compilation errors by adding a missing semicolon in `http_client.dart` and removing an unused import in `login_screen.dart`.

---
<a href="https://cursor.com/background-agent?bcId=bc-8bbff41f-4b2a-4b7d-b50f-ee652af117ec">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8bbff41f-4b2a-4b7d-b50f-ee652af117ec">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

