### PR TITLE
Debug login connection to localhost

### DIFF
--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -1,14 +1,14 @@
 import 'dart:convert';
 import 'package:http/http.dart' as http;
 import '../models/user.dart';
+import '../config/api_config.dart';
 
 class AuthService {
-  static const String baseUrl = 'https://urban-realty-production.up.railway.app/api/v1';
 
   static Future<Map<String, dynamic>> login(String email, String password) async {
     try {
       final response = await http.post(
-        Uri.parse('$baseUrl/auth/login'),
+        Uri.parse('${ApiConfig.baseUrl}/auth/login'),
         body: jsonEncode({
           'email': email,
           'password': password,
@@ -29,7 +29,7 @@ class AuthService {
   static Future<Map<String, dynamic>> register(String email, String password, String name, String role) async {
     try {
       final response = await http.post(
-        Uri.parse('$baseUrl/auth/register'),
+        Uri.parse('${ApiConfig.baseUrl}/auth/register'),
         body: jsonEncode({
           'email': email,
           'password': password,
@@ -52,7 +52,7 @@ class AuthService {
   static Future<Map<String, dynamic>> logout() async {
     try {
       final response = await http.post(
-        Uri.parse('$baseUrl/auth/logout'),
+        Uri.parse('${ApiConfig.baseUrl}/auth/logout'),
         headers: {'Content-Type': 'application/json'},
       );
 
@@ -69,7 +69,7 @@ class AuthService {
   static Future<User> getCurrentUser() async {
     try {
       final response = await http.get(
-        Uri.parse('$baseUrl/auth/me'),
+        Uri.parse('${ApiConfig.baseUrl}/auth/me'),
         headers: {'Content-Type': 'application/json'},
       );
 
@@ -87,7 +87,7 @@ class AuthService {
   static Future<bool> isAuthenticated() async {
     try {
       final response = await http.get(
-        Uri.parse('$baseUrl/auth/verify'),
+        Uri.parse('${ApiConfig.baseUrl}/auth/verify'),
         headers: {'Content-Type': 'application/json'},
       );
       return response.statusCode == 200;
@@ -99,7 +99,7 @@ class AuthService {
   static Future<Map<String, dynamic>> updateProfile(Map<String, dynamic> userData) async {
     try {
       final response = await http.put(
-        Uri.parse('$baseUrl/auth/profile'),
+        Uri.parse('${ApiConfig.baseUrl}/auth/profile'),
         body: jsonEncode(userData),
         headers: {'Content-Type': 'application/json'},
       );

--- a/mobile/lib/services/http_client.dart
+++ b/mobile/lib/services/http_client.dart
@@ -1,12 +1,12 @@
 import 'dart:convert';
 import 'package:http/http.dart' as http;
+import '../config/api_config.dart';
 
 class HttpClient {
-  static const String baseUrl = 'https://urban-realty-production.up.railway.app/api/v1';
   
   static Future<http.Response> get(String endpoint, {Map<String, String>? query, Map<String, String>? headers}) async {
     try {
-      Uri uri = Uri.parse('$baseUrl$endpoint');
+      Uri uri = Uri.parse('${ApiConfig.baseUrl}$endpoint');
       if (query != null) {
         uri = uri.replace(queryParameters: query.map((key, value) => MapEntry(key, value.toString())));
       }
@@ -23,7 +23,7 @@ class HttpClient {
   static Future<http.Response> post(String endpoint, {Object? body, Map<String, String>? headers}) async {
     try {
       final response = await http.post(
-        Uri.parse('$baseUrl$endpoint'),
+        Uri.parse('${ApiConfig.baseUrl}$endpoint'),
         body: body != null ? jsonEncode(body) : null,
         headers: headers ?? {'Content-Type': 'application/json'},
       );
@@ -36,7 +36,7 @@ class HttpClient {
   static Future<http.Response> put(String endpoint, {Object? body, Map<String, String>? headers}) async {
     try {
       final response = await http.put(
-        Uri.parse('$baseUrl$endpoint'),
+        Uri.parse('${ApiConfig.baseUrl}$endpoint'),
         body: body != null ? jsonEncode(body) : null,
         headers: headers ?? {'Content-Type': 'application/json'},
       );
@@ -49,7 +49,7 @@ class HttpClient {
   static Future<http.Response> delete(String endpoint, {Map<String, String>? headers}) async {
     try {
       final response = await http.delete(
-        Uri.parse('$baseUrl$endpoint'),
+        Uri.parse('${ApiConfig.baseUrl}$endpoint'),
         headers: headers ?? {'Content-Type': 'application/json'},
       );
       return response;

--- a/mobile/lib/services/property_service.dart
+++ b/mobile/lib/services/property_service.dart
@@ -1,9 +1,9 @@
 import 'dart:convert';
 import 'package:http/http.dart' as http;
 import '../models/property.dart';
+import '../config/api_config.dart';
 
 class PropertyService {
-  static const String baseUrl = 'https://urban-realty-production.up.railway.app/api/v1';
 
   static Future<List<Property>> getProperties({
     String? search,
@@ -24,7 +24,7 @@ class PropertyService {
       if (page != null) queryParams['page'] = page.toString();
       if (limit != null) queryParams['limit'] = limit.toString();
 
-      final uri = Uri.parse('$baseUrl/properties').replace(queryParameters: queryParams);
+      final uri = Uri.parse('${ApiConfig.baseUrl}/properties').replace(queryParameters: queryParams);
       final response = await http.get(uri);
 
       if (response.statusCode == 200) {
@@ -40,7 +40,7 @@ class PropertyService {
 
   static Future<Property> getPropertyById(String id) async {
     try {
-      final response = await http.get(Uri.parse('$baseUrl/properties/$id'));
+      final response = await http.get(Uri.parse('${ApiConfig.baseUrl}/properties/$id'));
       
       if (response.statusCode == 200) {
         final data = jsonDecode(response.body);
@@ -55,7 +55,7 @@ class PropertyService {
 
   static Future<List<Property>> getFeaturedProperties() async {
     try {
-      final response = await http.get(Uri.parse('$baseUrl/properties/featured'));
+      final response = await http.get(Uri.parse('${ApiConfig.baseUrl}/properties/featured'));
       
       if (response.statusCode == 200) {
         final List<dynamic> data = jsonDecode(response.body);
@@ -70,7 +70,7 @@ class PropertyService {
 
   static Future<List<Property>> getRecentlyViewedProperties() async {
     try {
-      final response = await http.get(Uri.parse('$baseUrl/properties/recently-viewed'));
+      final response = await http.get(Uri.parse('${ApiConfig.baseUrl}/properties/recently-viewed'));
       
       if (response.statusCode == 200) {
         final List<dynamic> data = jsonDecode(response.body);
@@ -85,7 +85,7 @@ class PropertyService {
 
   static Future<Map<String, dynamic>> list() async {
     try {
-      final response = await http.get(Uri.parse('$baseUrl/properties'));
+      final response = await http.get(Uri.parse('${ApiConfig.baseUrl}/properties'));
       
       if (response.statusCode == 200) {
         final data = jsonDecode(response.body);
@@ -101,7 +101,7 @@ class PropertyService {
   static Future<Map<String, dynamic>> searchSuggestions(String query) async {
     try {
       final response = await http.get(
-        Uri.parse('$baseUrl/properties/search-suggestions?q=$query'),
+        Uri.parse('${ApiConfig.baseUrl}/properties/search-suggestions?q=$query'),
       );
       
       if (response.statusCode == 200) {
@@ -117,7 +117,7 @@ class PropertyService {
 
   static Future<Map<String, dynamic>> detail(String id) async {
     try {
-      final response = await http.get(Uri.parse('$baseUrl/properties/$id'));
+      final response = await http.get(Uri.parse('${ApiConfig.baseUrl}/properties/$id'));
       
       if (response.statusCode == 200) {
         final data = jsonDecode(response.body);
@@ -133,7 +133,7 @@ class PropertyService {
   static Future<Map<String, dynamic>> contact(String propertyId, Map<String, dynamic> contactData) async {
     try {
       final response = await http.post(
-        Uri.parse('$baseUrl/properties/$propertyId/contact'),
+        Uri.parse('${ApiConfig.baseUrl}/properties/$propertyId/contact'),
         body: jsonEncode(contactData),
         headers: {'Content-Type': 'application/json'},
       );
@@ -153,7 +153,7 @@ class PropertyService {
       // Create multipart request for property data and images
       final request = http.MultipartRequest(
         'POST',
-        Uri.parse('$baseUrl/properties'),
+        Uri.parse('${ApiConfig.baseUrl}/properties'),
       );
 
       // Add property data as fields


### PR DESCRIPTION
Centralize API configuration by removing hardcoded URLs from service files to ensure consistent use of the production API.

The app was attempting to connect to `localhost:3000` despite `api_config.dart` being set to the production URL. This was due to `auth_service.dart`, `http_client.dart`, and `property_service.dart` having their own hardcoded base URLs, leading to inconsistent API calls. This PR fixes the issue by making all services use the `ApiConfig.baseUrl`.

---
<a href="https://cursor.com/background-agent?bcId=bc-0c00694d-65e6-47db-b0f9-5257f1779afa">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0c00694d-65e6-47db-b0f9-5257f1779afa">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

