### PR TITLE
Fix column widget argument error in profile screen

### DIFF
--- a/mobile/lib/screens/profile_screen.dart
+++ b/mobile/lib/screens/profile_screen.dart
@@ -267,23 +267,22 @@ class _ProfileScreenState extends State<ProfileScreen> {
                                   Icons.description,
                                   () => Navigator.of(context).pushNamed('/terms'),
                                 ),
-                              ],
-                              
-                              const SizedBox(height: 20),
-                              ElevatedButton(
-                                onPressed: () async {
-                                  await authProvider.logout();
-                                  if (mounted) {
-                                    Navigator.of(context).pushReplacementNamed('/');
-                                  }
-                                },
-                                style: ElevatedButton.styleFrom(
-                                  backgroundColor: Colors.red,
-                                  foregroundColor: Colors.white,
+                                const SizedBox(height: 20),
+                                ElevatedButton(
+                                  onPressed: () async {
+                                    await authProvider.logout();
+                                    if (mounted) {
+                                      Navigator.of(context).pushReplacementNamed('/');
+                                    }
+                                  },
+                                  style: ElevatedButton.styleFrom(
+                                    backgroundColor: Colors.red,
+                                    foregroundColor: Colors.white,
+                                  ),
+                                  child: const Text('Logout'),
                                 ),
-                                child: const Text('Logout'),
-                              ),
-                              const SizedBox(height: 8),
+                                const SizedBox(height: 8),
+                              ],
                             );
                           },
                         ),


### PR DESCRIPTION
Fix 'Too many positional arguments' error by correctly structuring the `Column`'s children list.

---
<a href="https://cursor.com/background-agent?bcId=bc-4b99068e-e9ac-42f8-8771-753906a9e623">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4b99068e-e9ac-42f8-8771-753906a9e623">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

