### PR TITLE
Fix missing arguments and print statements

### DIFF
--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -101,7 +101,7 @@ class MyApp extends StatelessWidget {
               '/notifications': (context) => const NotificationsScreen(),
               // Property routes
               '/property-detail': (context) => PropertyDetailScreen(
-                propertyId: ModalRoute.of(context)!.settings.arguments as String,
+                id: ModalRoute.of(context)!.settings.arguments as String,
               ),
               '/edit-property': (context) => const EditPropertyPage(),
               // Developer routes

--- a/mobile/lib/providers/auth_provider.dart
+++ b/mobile/lib/providers/auth_provider.dart
@@ -79,7 +79,7 @@ class AuthProvider extends ChangeNotifier {
       _user = null;
       notifyListeners();
       // Log the error but don't throw it to prevent app crashes
-      print('Logout error: $e');
+      debugPrint('Logout error: $e');
     }
   }
 

--- a/mobile/lib/screens/profile_screen.dart
+++ b/mobile/lib/screens/profile_screen.dart
@@ -270,9 +270,10 @@ class _ProfileScreenState extends State<ProfileScreen> {
                                 const SizedBox(height: 20),
                                 ElevatedButton(
                                   onPressed: () async {
+                                    final navigator = Navigator.of(context);
                                     await authProvider.logout();
                                     if (mounted) {
-                                      Navigator.of(context).pushReplacementNamed('/');
+                                      navigator.pushReplacementNamed('/');
                                     }
                                   },
                                   style: ElevatedButton.styleFrom(

--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -86,7 +86,7 @@ class AuthService {
     } catch (e) {
       // Don't throw exception for logout failures, just return empty response
       // This prevents app crashes when server is unavailable
-      print('Logout error: $e');
+      debugPrint('Logout error: $e');
       return {};
     }
   }


### PR DESCRIPTION
Fixes compilation errors for route parameters and resolves linting warnings for `print` statements and `BuildContext` usage across async gaps.

The `BuildContext` fix in `profile_screen.dart` addresses the `use_build_context_synchronously` warning by capturing `Navigator.of(context)` before an `await` call, preventing potential issues if the widget is unmounted during the async operation.

---
<a href="https://cursor.com/background-agent?bcId=bc-e7aa10f2-0b60-4e3f-81f2-bdae1fbcee48">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e7aa10f2-0b60-4e3f-81f2-bdae1fbcee48">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

