### PR TITLE
Refactor urban realty project across platforms

### DIFF
--- a/URBAN_REALTY_REFACTORING_MASTER_REPORT.md
+++ b/URBAN_REALTY_REFACTORING_MASTER_REPORT.md
@@ -21,6 +21,17 @@ This file is the single source of truth for all refactoring work performed acros
 
 ## Detailed Actions This Session
 
+### Phase 3 – Step 19: Add ESLint rule to prevent inline styles
+- Added `eslint-plugin-react` to client devDependencies.
+- Updated `client/eslint.config.js`:
+  - Enabled React recommended rules with `settings.react.version: 'detect'`.
+  - Disabled legacy `react/react-in-jsx-scope` for React 17+.
+  - Forbid inline `style` prop via `react/forbid-component-props`.
+  - Added Node globals override for config files (Vite/Tailwind) to prevent `no-undef`.
+- Ran lint and captured current violations:
+  - Many `react/prop-types` gaps and some missing imports/usages. These will be addressed alongside component refactors in later steps (Forms, UI kit adoption).
+- Outcome: Enforced no-inline-style policy across client; prepared for ongoing CSS consolidation.
+
 ### Phase 4 – Step 36: Flutter Project Structure Optimization (continuation)
 - Added barrel exports to enable clean imports:
   - `mobile/lib/core/config/index.dart`

--- a/client/eslint.config.js
+++ b/client/eslint.config.js
@@ -1,6 +1,7 @@
 import js from '@eslint/js'
 import globals from 'globals'
 import reactHooks from 'eslint-plugin-react-hooks'
+import react from 'eslint-plugin-react'
 import reactRefresh from 'eslint-plugin-react-refresh'
 
 export default [
@@ -16,18 +17,38 @@ export default [
         sourceType: 'module',
       },
     },
+    settings: {
+      react: { version: 'detect' },
+    },
     plugins: {
       'react-hooks': reactHooks,
       'react-refresh': reactRefresh,
+      'react': react,
     },
     rules: {
       ...js.configs.recommended.rules,
+      ...react.configs.recommended.rules,
       ...reactHooks.configs.recommended.rules,
       'no-unused-vars': ['error', { varsIgnorePattern: '^[A-Z_]' }],
+      'react/react-in-jsx-scope': 'off',
+      'react/no-danger': 'warn',
+      // Prevent inline styles to enforce centralized styling
+      'react/style-prop-object': 'error',
+      'react/forbid-component-props': ['error', { forbid: [{ propName: 'style' }] }],
       'react-refresh/only-export-components': [
         'warn',
         { allowConstantExport: true },
       ],
+    },
+  },
+  {
+    files: ['**/*.config.*', '**/*.cjs', 'vite.config.js', 'tailwind.config.js'],
+    languageOptions: {
+      globals: { ...globals.node },
+      sourceType: 'module',
+    },
+    rules: {
+      'no-undef': 'off',
     },
   },
 ]

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -48,6 +48,7 @@
         "@vitejs/plugin-react": "^4.3.4",
         "autoprefixer": "^10.4.16",
         "eslint": "^9.21.0",
+        "eslint-plugin-react": "^7.37.5",
         "eslint-plugin-react-hooks": "^5.1.0",
         "eslint-plugin-react-refresh": "^0.4.19",
         "globals": "^15.15.0",

--- a/client/package.json
+++ b/client/package.json
@@ -50,6 +50,7 @@
     "@vitejs/plugin-react": "^4.3.4",
     "autoprefixer": "^10.4.16",
     "eslint": "^9.21.0",
+    "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^5.1.0",
     "eslint-plugin-react-refresh": "^0.4.19",
     "globals": "^15.15.0",


### PR DESCRIPTION
Enforce no-inline-style rule in client-side React code to promote centralized styling and eliminate CSS redundancy.

This change is part of Phase 3, Step 19 of the Urban Realty Refactoring Guide, which aims to optimize CSS and consolidate styling approaches. By forbidding inline styles via ESLint, we ensure that styling is managed through dedicated CSS files or styled-components, improving maintainability and consistency.

---
<a href="https://cursor.com/background-agent?bcId=bc-6e7ede04-cd34-4f86-8e84-2914191beb96">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6e7ede04-cd34-4f86-8e84-2914191beb96">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

