### PR TITLE
Refactor urban realty project across platforms

### DIFF
--- a/URBAN_REALTY_REFACTORING_MASTER_REPORT.md
+++ b/URBAN_REALTY_REFACTORING_MASTER_REPORT.md
@@ -160,6 +160,16 @@ Baseline metrics (quick):
 - Files: server 75, client 194, mobile 116
 - Remaining inline style occurrences detected by grep: 2 files (now addressed)
 
+### Phase 3 – Step 19: Inline style removals (map components, this session)
+- Moved inline container styles to CSS for maps:
+  - `client/src/components/property/PropertyMap.jsx` -> `PropertyMap.css` using `map-container map-container--sm`
+  - `client/src/components/property/PropertiesMap.jsx` -> `PropertiesMap.css` using `map-container map-container--lg`, added `.map-empty` for empty state
+- Updated components to use `mapContainerClassName` instead of `mapContainerStyle`.
+
+Verification:
+- Vite production build succeeded after changes.
+- Grep scan now reports 0 inline `style={{` usage in `client/src`.
+
 ### Phase 1 – Step 2: Backup & Version Control Setup (this session)
 ### Phase 3 – Step 21: Form Handling Standardization (this session)
 - Added React Hook Form and resolvers to client dependencies.
@@ -192,3 +202,11 @@ Baseline metrics update:
 
 Outcome:
 - Phase 1 steps 1–5 verified and completed. Proceeding to Phase 3 (client) and Phase 4 (mobile) next.
+
+## Session Verification Updates
+- Root `npm ci` and audit: 0 vulnerabilities at root; client reports 7 (1 low, 5 moderate, 1 critical) from transitive packages. Will address in Phase 3 Step 29 (bundle/deps optimization).
+- Client build outputs large chunks; to be addressed with route-level code splitting in Step 29.
+
+## Next Immediate Actions
+- Phase 3 Step 29: Introduce dynamic imports for large routes and configure Rollup `manualChunks`.
+- Phase 4 Step 36: Continue file moves in Flutter; tooling not available in this environment, will proceed with code-level re-exports and documentation, and run `flutter analyze` when tooling is accessible.

--- a/client/src/components/property/PropertiesMap.css
+++ b/client/src/components/property/PropertiesMap.css
@@ -1,0 +1,20 @@
+.map-container {
+  width: 100%;
+  border-radius: 8px;
+  border: 1px solid #78CADC;
+}
+
+.map-container--lg {
+  height: 500px;
+}
+
+.map-empty {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 500px;
+  background-color: #0B1011;
+  border-radius: 8px;
+  border: 1px solid #78CADC;
+}
+

--- a/client/src/components/property/PropertiesMap.jsx
+++ b/client/src/components/property/PropertiesMap.jsx
@@ -1,13 +1,9 @@
 import { useEffect, useRef, useState } from 'react';
 import { Box, Typography } from '@mui/material';
 import { LoadScript, GoogleMap, Marker, InfoWindow } from '@react-google-maps/api';
+import './PropertiesMap.css';
 
-const containerStyle = {
-  width: '100%',
-  height: '500px',
-  borderRadius: '8px',
-  border: '1px solid #78CADC'
-};
+// Styles moved to CSS to avoid inline-style usage
 
 const PropertiesMap = ({ properties, selectedProperty, onMarkerClick }) => {
   const mapRef = useRef(null);
@@ -37,15 +33,7 @@ const PropertiesMap = ({ properties, selectedProperty, onMarkerClick }) => {
 
   if (!properties || properties.length === 0) {
     return (
-      <Box sx={{ 
-        display: 'flex', 
-        justifyContent: 'center', 
-        alignItems: 'center',
-        height: '500px',
-        backgroundColor: '#0B1011',
-        borderRadius: '8px',
-        border: '1px solid #78CADC'
-      }}>
+      <Box className="map-empty">
         <Typography variant="body2" color="text.secondary">
           No properties to display on map.
         </Typography>
@@ -78,7 +66,7 @@ const PropertiesMap = ({ properties, selectedProperty, onMarkerClick }) => {
       }}
     >
       <GoogleMap
-        mapContainerStyle={containerStyle}
+        mapContainerClassName="map-container map-container--lg"
         zoom={10}
         onLoad={onLoad}
         onUnmount={onUnmount}

--- a/client/src/components/property/PropertyMap.css
+++ b/client/src/components/property/PropertyMap.css
@@ -1,0 +1,10 @@
+.map-container {
+  width: 100%;
+  height: 400px;
+  border-radius: 8px;
+}
+
+.map-container--sm {
+  height: 400px;
+}
+

--- a/client/src/components/property/PropertyMap.jsx
+++ b/client/src/components/property/PropertyMap.jsx
@@ -1,12 +1,9 @@
 import { useEffect, useRef, useState } from 'react';
 import { Box, Typography } from '@mui/material';
 import { LoadScript, GoogleMap, Marker, InfoWindow } from '@react-google-maps/api';
+import './PropertyMap.css';
 
-const containerStyle = {
-  width: '100%',
-  height: '400px',
-  borderRadius: '8px'
-};
+// Styles moved to CSS to avoid inline-style usage
 
 const PropertyMap = ({ location, address }) => {
   const mapRef = useRef(null);
@@ -47,7 +44,7 @@ const PropertyMap = ({ location, address }) => {
       }}
       >
       <GoogleMap
-        mapContainerStyle={containerStyle}
+        mapContainerClassName="map-container map-container--sm"
         center={center}
         zoom={15}
         onLoad={onLoad}


### PR DESCRIPTION
Remove inline styles from client map components and move them to dedicated CSS files to improve styling consistency and maintainability.

---
<a href="https://cursor.com/background-agent?bcId=bc-4f2a8f91-6cb4-457c-bd39-4785ccdff9c5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4f2a8f91-6cb4-457c-bd39-4785ccdff9c5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

