### PR TITLE
Fix module resolution error on railway

### DIFF
--- a/server/constants/index.js
+++ b/server/constants/index.js
@@ -13,7 +13,7 @@ const {
   SUCCESS_MESSAGES,
   API_ENDPOINTS,
   UPLOAD_LIMITS
-} = require(path.resolve(__dirname, '../shared/constants/index.cjs'));
+} = require(path.resolve(__dirname, '../../shared/constants/index.cjs'));
 
 // Server-specific constants (extending shared constants)
 


### PR DESCRIPTION
Update relative path for shared constants to fix `MODULE_NOT_FOUND` error in Railway deployments.

The previous path `../shared/constants/index.cjs` worked locally but failed in the Railway container, which expected `../../shared/constants/index.cjs` from `server/constants/index.js` due to differing path resolution.

---
<a href="https://cursor.com/background-agent?bcId=bc-71350864-d5fc-4e92-8412-f4575a92e0de">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-71350864-d5fc-4e92-8412-f4575a92e0de">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

