### PR TITLE
Fix compilation errors in flutter project

### DIFF
--- a/mobile/lib/core/config/index.dart
+++ b/mobile/lib/core/config/index.dart
@@ -1,6 +1,3 @@
-export '../config/api_config.dart';
-export '../config/app_theme.dart';
-export '../config/environment_config.dart';
-export * from "./api_config.dart";
-export * from "./app_theme.dart";
-export * from "./environment_config.dart";
+export '../../config/api_config.dart';
+export '../../config/app_theme.dart';
+export '../../config/environment_config.dart';

--- a/mobile/lib/services/http_client.dart
+++ b/mobile/lib/services/http_client.dart
@@ -1,0 +1,24 @@
+import 'package:dio/dio.dart';
+import '../config/api_config.dart';
+import 'api_service.dart';
+
+class HttpClient {
+  static final ApiService _api = ApiService();
+
+  static Future<Response> get(String path, {Map<String, dynamic>? query}) {
+    return _api.dio.get(path, queryParameters: query);
+  }
+
+  static Future<Response> post(String path, {dynamic body}) {
+    return _api.dio.post(path, data: body);
+  }
+
+  static Future<Response> put(String path, {dynamic body}) {
+    return _api.dio.put(path, data: body);
+  }
+
+  static Future<Response> delete(String path, {dynamic body}) {
+    return _api.dio.delete(path, data: body);
+  }
+}
+

--- a/mobile/lib/services/property_service.dart
+++ b/mobile/lib/services/property_service.dart
@@ -121,7 +121,7 @@ class PropertyService {
 
   Future<void> deleteProperty(String id) async {
     try {
-      await _api_service.dio.delete('/properties/$id');
+      await _apiService.dio.delete('/properties/$id');
     } on DioException catch (e) {
       throw Exception('Error deleting property: ${e.message}');
     }

--- a/mobile/lib/shared/models/index.dart
+++ b/mobile/lib/shared/models/index.dart
@@ -1,5 +1,5 @@
-// Re-export shared models when moved here
-export * from "./user.dart";
-export * from "./property.dart";
-export * from "./subscription.dart";
-export * from "./developer.dart";
+// Re-export shared models
+export '../../models/user.dart';
+export '../../models/property.dart';
+export '../../models/subscription.dart';
+export '../../models/developer.dart';

--- a/mobile/lib/shared/providers/index.dart
+++ b/mobile/lib/shared/providers/index.dart
@@ -1,3 +1,3 @@
-export * from './auth_provider.dart';
-export * from './properties_provider.dart';
-export * from './theme_provider.dart';
+export 'auth_provider.dart';
+export 'properties_provider.dart';
+export 'theme_provider.dart';

--- a/mobile/lib/shared/widgets/index.dart
+++ b/mobile/lib/shared/widgets/index.dart
@@ -1,4 +1,2 @@
 export '../../widgets/property_card.dart';
 export '../../widgets/form_text_field.dart';
-export * from "./form_text_field.dart";
-export * from "./property_card.dart";


### PR DESCRIPTION
Fix Dart compilation errors by correcting invalid export syntax, adding a missing `HttpClient` shim, and resolving a typo in `PropertyService`.

The project was using TypeScript-style `export * from` syntax which is not valid in Dart, leading to numerous compilation errors. Additionally, the `HttpClient` class was referenced but not defined, and a typo in `PropertyService` prevented proper API calls.

---
<a href="https://cursor.com/background-agent?bcId=bc-e1bfae87-9d44-404b-a30f-e6fa9d29709e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e1bfae87-9d44-404b-a30f-e6fa9d29709e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

