### PR TITLE
Changes from background agent bc-4a68f560-b331-4c05-a5cd-6ca10333a4c5

### DIFF
--- a/mobile/lib/widgets/property_card.dart
+++ b/mobile/lib/widgets/property_card.dart
@@ -169,7 +169,7 @@ class PropertyCard extends StatelessWidget {
                       const Icon(Icons.square_foot, size: 16, color: Colors.grey),
                       const SizedBox(width: 4),
                       Text(
-                        "${property.area} sq ft",
+                        "${_formatArea(property.area)} sq ft",
                         style: const TextStyle(color: Colors.grey),
                       ),
                     ],
@@ -191,5 +191,14 @@ class PropertyCard extends StatelessWidget {
       (m) => ",",
     );
     return "\$${withSeparators}";
+  }
+
+  String _formatArea(double area) {
+    final String raw = area.toStringAsFixed(0);
+    final String withSeparators = raw.replaceAllMapped(
+      RegExp(r"\B(?=(\d{3})+(?!\d))"),
+      (m) => ",",
+    );
+    return withSeparators;
   }
 }

--- a/mobile/test/widget_test.dart
+++ b/mobile/test/widget_test.dart
@@ -13,8 +13,9 @@ void main() {
   testWidgets('App smoke test', (WidgetTester tester) async {
     // Build our app and trigger a frame.
     await tester.pumpWidget(const MyApp());
+    await tester.pumpAndSettle();
 
-    // Verify that our app shows "Hello World".
-    expect(find.text('Hello World'), findsOneWidget);
+    // App initially shows login screen; verify stable text.
+    expect(find.text('Welcome Back'), findsOneWidget);
   });
 }


### PR DESCRIPTION
Fix Flutter widget tests by updating assertions and formatting property area values.

The `App smoke test` failed because it was looking for "Hello World" which is no longer present, and required `pumpAndSettle()` to correctly render the initial login screen. The `PropertyCard` test failed because the area value was not formatted with thousands separators, leading to a mismatch with the expected text.

---
<a href="https://cursor.com/background-agent?bcId=bc-4a68f560-b331-4c05-a5cd-6ca10333a4c5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4a68f560-b331-4c05-a5cd-6ca10333a4c5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

