### PR TITLE
Changes from background agent bc-701068e6-72d5-4e1c-ac9e-cb64ed3eb0d8

### DIFF
--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -34,13 +34,14 @@ void main() async {
 }
 
 class MyApp extends StatelessWidget {
-  const MyApp({super.key});
+  final bool enableAutoLogin;
+  const MyApp({super.key, this.enableAutoLogin = true});
 
   @override
   Widget build(BuildContext context) {
     return MultiProvider(
       providers: [
-        ChangeNotifierProvider(create: (_) => AuthProvider()),
+        ChangeNotifierProvider(create: (_) => AuthProvider(autoLogin: enableAutoLogin)),
         ChangeNotifierProvider(create: (_) => PropertiesProvider()),
         ChangeNotifierProvider(create: (_) => ThemeProvider()),
       ],

--- a/mobile/lib/shared/providers/auth_provider.dart
+++ b/mobile/lib/shared/providers/auth_provider.dart
@@ -5,8 +5,8 @@ import '../../models/user.dart';
 import '../../services/auth_service.dart';
 
 class AuthProvider extends ChangeNotifier {
-  final AuthService _authService = AuthService();
-  final FlutterSecureStorage _secureStorage = const FlutterSecureStorage();
+  final AuthService _authService;
+  final FlutterSecureStorage _secureStorage;
 
   User? _user;
   String? _token;
@@ -19,8 +19,15 @@ class AuthProvider extends ChangeNotifier {
   String? get error => _error;
   bool get isAuthenticated => _token != null && _user != null;
 
-  AuthProvider() {
-    tryAutoLogin();
+  AuthProvider({
+    AuthService? authService,
+    FlutterSecureStorage? secureStorage,
+    bool autoLogin = true,
+  })  : _authService = authService ?? AuthService(),
+        _secureStorage = secureStorage ?? const FlutterSecureStorage() {
+    if (autoLogin) {
+      tryAutoLogin();
+    }
   }
 
   Future<bool> login(String email, String password) async {

--- a/mobile/test/widget_test.dart
+++ b/mobile/test/widget_test.dart
@@ -12,7 +12,7 @@ import 'package:urban_realty_mobile/main.dart';
 void main() {
   testWidgets('App smoke test', (WidgetTester tester) async {
     // Build our app and trigger a frame.
-    await tester.pumpWidget(const MyApp());
+    await tester.pumpWidget(const MyApp(enableAutoLogin: false));
     await tester.pumpAndSettle();
 
     // App initially shows login screen; verify stable text.


### PR DESCRIPTION
Disable auto-login in widget tests to prevent `pumpAndSettle` timeouts.

The `App smoke test` was failing due to `pumpAndSettle timed out`. This was caused by `AuthProvider` attempting an asynchronous `tryAutoLogin` operation (involving `FlutterSecureStorage`) during widget initialization, which can block the test runner. By introducing an `enableAutoLogin` flag, tests can now disable this behavior, allowing `pumpAndSettle` to complete successfully.

---
<a href="https://cursor.com/background-agent?bcId=bc-701068e6-72d5-4e1c-ac9e-cb64ed3eb0d8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-701068e6-72d5-4e1c-ac9e-cb64ed3eb0d8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

