### PR TITLE
Changes from background agent bc-dfb4a374-ff52-4ee2-a4d0-a04324b23b0f

### DIFF
--- a/mobile/lib/features/auth/login_screen.dart
+++ b/mobile/lib/features/auth/login_screen.dart
@@ -139,8 +139,10 @@ class LoginScreen extends StatelessWidget {
                                 },
                               ),
                               const SizedBox(height: 24),
-                              Row(
-                                mainAxisAlignment: MainAxisAlignment.center,
+                              Wrap(
+                                alignment: WrapAlignment.center,
+                                crossAxisAlignment: WrapCrossAlignment.center,
+                                spacing: 4,
                                 children: [
                                   const Text("Don't have an account? "),
                                   TextButton(


### PR DESCRIPTION
Refactor login screen's bottom auth prompt from Row to Wrap to prevent horizontal overflow.

The "App smoke test" was failing due to a `RenderFlex overflowed` error in `login_screen.dart` at line 142. The `Row` widget containing the "Don't have an account? Sign Up" prompt could not adapt to constrained widths, causing content to overflow. This change replaces the `Row` with a `Wrap` widget, allowing the text and button to flow onto multiple lines and resolve the layout issue.

---
<a href="https://cursor.com/background-agent?bcId=bc-dfb4a374-ff52-4ee2-a4d0-a04324b23b0f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-dfb4a374-ff52-4ee2-a4d0-a04324b23b0f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

