### PR TITLE
Changes from background agent bc-77826df7-14ec-45c4-8a8a-f7f3f009a092

### DIFF
--- a/mobile/lib/widgets/property_card.dart
+++ b/mobile/lib/widgets/property_card.dart
@@ -190,7 +190,7 @@ class PropertyCard extends StatelessWidget {
       RegExp(r"\B(?=(\d{3})+(?!\d))"),
       (m) => ",",
     );
-    return "\$${withSeparators}";
+    return "\$$withSeparators";
   }
 
   String _formatArea(double area) {


### PR DESCRIPTION
Fix `unnecessary_brace_in_string_interps` lint in `lib/widgets/property_card.dart`.

---
<a href="https://cursor.com/background-agent?bcId=bc-77826df7-14ec-45c4-8a8a-f7f3f009a092">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-77826df7-14ec-45c4-8a8a-f7f3f009a092">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

