### PR TITLE
Fix missing railway deploy action

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -220,11 +220,16 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Deploy to Railway (Staging)
-        uses: railway-app/railway-deploy@v1
-        with:
-          railway-token: ${{ secrets.RAILWAY_TOKEN }}
-          service: urban-realty-staging
-          detach: true
+        run: echo "Starting Railway deployment to Staging"
+
+      - name: Install Railway CLI
+        run: npm install -g @railway/cli
+
+      - name: Deploy via Railway CLI (Staging)
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+        run: |
+          railway up --service "urban-realty-staging" --detach
 
       - name: Run smoke tests
         run: |
@@ -243,11 +248,16 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Deploy to Railway (Production)
-        uses: railway-app/railway-deploy@v1
-        with:
-          railway-token: ${{ secrets.RAILWAY_TOKEN }}
-          service: urban-realty-production
-          detach: true
+        run: echo "Starting Railway deployment to Production"
+
+      - name: Install Railway CLI
+        run: npm install -g @railway/cli
+
+      - name: Deploy via Railway CLI (Production)
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+        run: |
+          railway up --service "urban-realty-production" --detach
 
       - name: Run production smoke tests
         run: |


### PR DESCRIPTION
Replace deprecated `railway-app/railway-deploy` action with Railway CLI steps to fix 'repository not found' error.

---
<a href="https://cursor.com/background-agent?bcId=bc-6d987cfd-c845-45f3-8ddf-8373b44df7e1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6d987cfd-c845-45f3-8ddf-8373b44df7e1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

