### PR TITLE
Changes from background agent bc-3518d0c1-0fab-44d5-bfb5-1685b179b23c

### DIFF
--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -26,6 +26,8 @@ import 'features/agent/agent_properties_screen.dart';
 import 'features/developers/developers_list_screen.dart';
 import 'features/notifications/notifications_screen.dart';
 import 'features/splash/splash_screen.dart';
+import 'screens/favorites_screen.dart';
+import 'screens/properties_screen.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -115,6 +117,22 @@ class MyApp extends StatelessWidget {
                 case '/notifications':
                   return MaterialPageRoute(builder: (context) => const NotificationsScreen());
                 case '/developers':
+                  return MaterialPageRoute(builder: (context) => const DevelopersListScreen());
+                // Add missing routes that are being called with hyphen format
+                case '/agent-leads':
+                  return MaterialPageRoute(builder: (context) => const AgentLeadsScreen());
+                case '/agent-properties':
+                  return MaterialPageRoute(builder: (context) => const AgentPropertiesScreen());
+                case '/agent-inquiries':
+                  return MaterialPageRoute(builder: (context) => const AgentInquiriesScreen());
+                case '/agent-analytics':
+                  return MaterialPageRoute(builder: (context) => const AgentAnalyticsScreen());
+                // Add other missing routes
+                case '/favorites':
+                  return MaterialPageRoute(builder: (context) => const FavoritesScreen());
+                case '/properties':
+                  return MaterialPageRoute(builder: (context) => const PropertiesScreen());
+                case '/developer-add':
                   return MaterialPageRoute(builder: (context) => const DevelopersListScreen());
                 default:
                   return MaterialPageRoute(builder: (context) => const HomeTabs());


### PR DESCRIPTION
Add missing route definitions and imports to fix 'Could not find a generator for route' errors.

The application was attempting to navigate to routes using a hyphenated format (e.g., `/agent-leads`) or other undefined paths, which were not explicitly defined in the `onGenerateRoute` function, leading to navigation failures. This PR adds the necessary route entries and corresponding screen imports.

---
<a href="https://cursor.com/background-agent?bcId=bc-3518d0c1-0fab-44d5-bfb5-1685b179b23c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3518d0c1-0fab-44d5-bfb5-1685b179b23c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

