### PR TITLE
Fix property detail and admin dashboard errors

### DIFF
--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -81,7 +81,11 @@ class MyApp extends StatelessWidget {
                   return MaterialPageRoute(builder: (context) => const AddPropertyScreen());
                 case '/property-detail':
                   final args = settings.arguments as String?;
-                  return MaterialPageRoute(builder: (context) => PropertyDetailScreen(propertyId: args ?? ''));
+                  if (args == null || args.isEmpty) {
+                    // If no property ID provided, navigate back to home
+                    return MaterialPageRoute(builder: (context) => const HomeTabs());
+                  }
+                  return MaterialPageRoute(builder: (context) => PropertyDetailScreen(propertyId: args));
                 case '/search':
                   return MaterialPageRoute(builder: (context) => const SearchScreen());
                 case '/about':

--- a/mobile/lib/screens/dashboard_screen.dart
+++ b/mobile/lib/screens/dashboard_screen.dart
@@ -1330,11 +1330,18 @@ class _DashboardScreenState extends State<DashboardScreen> {
         elevation: 4,
         child: InkWell(
           onTap: () {
-            Navigator.pushNamed(
-              context,
-              '/property-detail',
-              arguments: property['_id']?.toString() ?? '',
-            );
+            final propertyId = property['_id']?.toString();
+            if (propertyId != null && propertyId.isNotEmpty) {
+              Navigator.pushNamed(
+                context,
+                '/property-detail',
+                arguments: propertyId,
+              );
+            } else {
+              ScaffoldMessenger.of(context).showSnackBar(
+                const SnackBar(content: Text('Property ID not available')),
+              );
+            }
           },
           borderRadius: BorderRadius.circular(16),
                       child: Column(

--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -42,12 +42,12 @@ class AuthService {
   Future<void> logout() async {
     try {
       // The backend doesn't seem to have a formal logout endpoint to invalidate tokens.
-      // If it did, we would call it here.
       // For now, logout is a client-side operation (handled by AuthProvider).
-      await _apiService.dio.post('/auth/logout');
-    } on DioException catch (e) {
+      // We'll skip the API call to avoid the error since the backend doesn't have this endpoint.
+      developer.log('Logout completed (client-side only)', name: 'AuthService.logout');
+    } catch (e) {
       // Don't throw exception for logout failures, just log it without using print.
-      developer.log('Logout error: ${e.message}', name: 'AuthService.logout');
+      developer.log('Logout error: ${e.toString()}', name: 'AuthService.logout');
     }
   }
 


### PR DESCRIPTION
Fix property detail navigation and remove erroneous logout API call.

The `/property-detail` route handler and its caller in `DashboardScreen` now validate the property ID to prevent navigation errors when the ID is missing. The `AuthService.logout` method no longer attempts to call a non-existent `/auth/logout` endpoint, resolving the associated error log.

---
<a href="https://cursor.com/background-agent?bcId=bc-dc2f8ed3-d50d-484f-9890-6de1bb15b19a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-dc2f8ed3-d50d-484f-9890-6de1bb15b19a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

