### PR TITLE
Changes from background agent bc-6fbe21d1-9056-4ada-8143-6159ae4c809e

### DIFF
--- a/mobile/lib/features/admin/admin_dashboard_screen.dart
+++ b/mobile/lib/features/admin/admin_dashboard_screen.dart
@@ -61,7 +61,10 @@ class _AdminDashboardScreenState extends State<AdminDashboardScreen>
   void initState() {
     super.initState();
     _tabController = TabController(length: 4, vsync: this);
-    _loadDashboardData();
+    // Use WidgetsBinding to ensure we're not in build phase
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _loadDashboardData();
+    });
   }
 
   @override
@@ -158,9 +161,11 @@ class _AdminDashboardScreenState extends State<AdminDashboardScreen>
     try {
       final propertiesProvider = Provider.of<PropertiesProvider>(context, listen: false);
       await propertiesProvider.fetchProperties();
-      setState(() {
-        recentProperties = propertiesProvider.properties.take(5).toList();
-      });
+      if (mounted) {
+        setState(() {
+          recentProperties = propertiesProvider.properties.take(5).toList();
+        });
+      }
     } catch (e) {
       throw Exception('Failed to load recent properties: $e');
     }

--- a/mobile/lib/features/properties/property_detail_screen.dart
+++ b/mobile/lib/features/properties/property_detail_screen.dart
@@ -27,7 +27,10 @@ class _PropertyDetailScreenState extends State<PropertyDetailScreen> {
   @override
   void initState() {
     super.initState();
-    _loadProperty();
+    // Use WidgetsBinding to ensure we're not in build phase
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _loadProperty();
+    });
   }
 
   Future<void> _loadProperty() async {
@@ -41,15 +44,19 @@ class _PropertyDetailScreenState extends State<PropertyDetailScreen> {
       await provider.fetchPropertyById(widget.propertyId);
       final loadedProperty = provider.selectedProperty;
       
-      setState(() {
-        property = loadedProperty;
-        isLoading = false;
-      });
+      if (mounted) {
+        setState(() {
+          property = loadedProperty;
+          isLoading = false;
+        });
+      }
     } catch (e) {
-      setState(() {
-        error = e.toString();
-        isLoading = false;
-      });
+      if (mounted) {
+        setState(() {
+          error = e.toString();
+          isLoading = false;
+        });
+      }
     }
   }
 

--- a/mobile/lib/shared/providers/properties_provider.dart
+++ b/mobile/lib/shared/providers/properties_provider.dart
@@ -36,7 +36,14 @@ class PropertiesProvider extends ChangeNotifier {
       _hasMore = true;
     }
     _error = null;
-    notifyListeners();
+    // Only notify listeners if we're not in build phase
+    if (!WidgetsBinding.instance.schedulerPhase.isInBuildPhase) {
+      notifyListeners();
+    } else {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        notifyListeners();
+      });
+    }
 
     try {
       final newProperties = await _propertyService.getProperties(
@@ -61,42 +68,86 @@ class PropertiesProvider extends ChangeNotifier {
       _error = e.toString();
     } finally {
       _isLoading = false;
-      notifyListeners();
+      // Only notify listeners if we're not in build phase
+      if (!WidgetsBinding.instance.schedulerPhase.isInBuildPhase) {
+        notifyListeners();
+      } else {
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          notifyListeners();
+        });
+      }
     }
   }
 
   Future<void> fetchPropertyById(String id) async {
     _isLoading = true;
     _error = null;
-    notifyListeners();
+    // Only notify listeners if we're not in build phase
+    if (!WidgetsBinding.instance.schedulerPhase.isInBuildPhase) {
+      notifyListeners();
+    } else {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        notifyListeners();
+      });
+    }
+    
     try {
       _selectedProperty = await _propertyService.getPropertyById(id);
     } catch (e) {
       _error = e.toString();
     } finally {
       _isLoading = false;
-      notifyListeners();
+      // Only notify listeners if we're not in build phase
+      if (!WidgetsBinding.instance.schedulerPhase.isInBuildPhase) {
+        notifyListeners();
+      } else {
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          notifyListeners();
+        });
+      }
     }
   }
 
   Future<void> fetchFeaturedProperties() async {
     _isLoading = true;
     _error = null;
-    notifyListeners();
+    // Only notify listeners if we're not in build phase
+    if (!WidgetsBinding.instance.schedulerPhase.isInBuildPhase) {
+      notifyListeners();
+    } else {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        notifyListeners();
+      });
+    }
+    
     try {
       _featuredProperties = await _propertyService.getFeaturedProperties();
     } catch (e) {
       _error = e.toString();
     } finally {
       _isLoading = false;
-      notifyListeners();
+      // Only notify listeners if we're not in build phase
+      if (!WidgetsBinding.instance.schedulerPhase.isInBuildPhase) {
+        notifyListeners();
+      } else {
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          notifyListeners();
+        });
+      }
     }
   }
 
   Future<bool> createProperty(Map<String, dynamic> propertyData, List<String> imagePaths) async {
     _isLoading = true;
     _error = null;
-    notifyListeners();
+    // Only notify listeners if we're not in build phase
+    if (!WidgetsBinding.instance.schedulerPhase.isInBuildPhase) {
+      notifyListeners();
+    } else {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        notifyListeners();
+      });
+    }
 
     try {
       await _propertyService.createProperty(propertyData, imagePaths);
@@ -107,7 +158,14 @@ class PropertiesProvider extends ChangeNotifier {
       return false;
     } finally {
       _isLoading = false;
-      notifyListeners();
+      // Only notify listeners if we're not in build phase
+      if (!WidgetsBinding.instance.schedulerPhase.isInBuildPhase) {
+        notifyListeners();
+      } else {
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          notifyListeners();
+        });
+      }
     }
   }
 

--- a/mobile/lib/widgets/quick_action_card.dart
+++ b/mobile/lib/widgets/quick_action_card.dart
@@ -38,29 +38,32 @@ class QuickActionCard extends StatelessWidget {
           ),
           child: Column(
             mainAxisAlignment: MainAxisAlignment.center,
+            mainAxisSize: MainAxisSize.min,
             children: [
               Container(
-                padding: const EdgeInsets.all(12),
+                padding: const EdgeInsets.all(8),
                 decoration: BoxDecoration(
                   color: color.withOpacity(0.1),
                   borderRadius: BorderRadius.circular(12),
                 ),
                 child: Icon(
                   icon,
-                  size: 32,
+                  size: 24,
                   color: color,
                 ),
               ),
-              const SizedBox(height: 12),
-              Text(
-                title,
-                style: theme.textTheme.titleMedium?.copyWith(
-                  fontWeight: FontWeight.w600,
-                  color: theme.colorScheme.onSurface,
+              const SizedBox(height: 8),
+              Flexible(
+                child: Text(
+                  title,
+                  style: theme.textTheme.bodyMedium?.copyWith(
+                    fontWeight: FontWeight.w600,
+                    color: theme.colorScheme.onSurface,
+                  ),
+                  textAlign: TextAlign.center,
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
                 ),
-                textAlign: TextAlign.center,
-                maxLines: 2,
-                overflow: TextOverflow.ellipsis,
               ),
             ],
           ),


### PR DESCRIPTION
Fix `setState()` during build errors and `RenderFlex` overflows, improving app stability and layout.

This PR addresses two main issues:
1.  **`setState()` or `markNeedsBuild()` called during build**: This was caused by `PropertiesProvider` calling `notifyListeners()` and `_loadProperty()`/`_loadDashboardData()` being invoked in `initState()`. The fix defers these calls using `WidgetsBinding.instance.addPostFrameCallback` and adds `mounted` checks to ensure state updates happen safely after the build phase.
2.  **`RenderFlex` overflow**: The `QuickActionCard` had fixed sizing causing content overflow. This is resolved by making the `Column` flexible, wrapping text in `Flexible`, and adjusting icon/padding sizes.

---
<a href="https://cursor.com/background-agent?bcId=bc-6fbe21d1-9056-4ada-8143-6159ae4c809e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6fbe21d1-9056-4ada-8143-6159ae4c809e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

