### PR TITLE
Fix type and render overflows

### DIFF
--- a/mobile/lib/features/admin/admin_dashboard_screen.dart
+++ b/mobile/lib/features/admin/admin_dashboard_screen.dart
@@ -194,7 +194,23 @@ class _AdminDashboardScreenState extends State<AdminDashboardScreen>
     );
   }
 
-  String _formatTimeAgo(DateTime dateTime) {
+  String _formatTimeAgo(dynamic date) {
+    // Accepts DateTime, ISO8601 string, or epoch (ms/seconds)
+    DateTime dateTime;
+    if (date is DateTime) {
+      dateTime = date;
+    } else if (date is String) {
+      dateTime = DateTime.tryParse(date) ?? DateTime.now();
+    } else if (date is int) {
+      // Heuristic: treat 13-digit as milliseconds, 10-digit as seconds
+      final isSeconds = date.toString().length <= 10;
+      dateTime = DateTime.fromMillisecondsSinceEpoch(
+        isSeconds ? date * 1000 : date,
+      );
+    } else {
+      dateTime = DateTime.now();
+    }
+
     final now = DateTime.now();
     final difference = now.difference(dateTime);
     
@@ -490,9 +506,7 @@ class _AdminDashboardScreenState extends State<AdminDashboardScreen>
                     'type': 'user',
                     'title': user['name'] ?? 'Unknown User',
                     'subtitle': user['email'] ?? '',
-                    'time': _formatTimeAgo(
-                      DateTime.tryParse(user['createdAt'] ?? '') ?? DateTime.now(),
-                    ),
+                    'time': _formatTimeAgo(user['createdAt']),
                   }).toList(),
                   onViewAll: () => Navigator.pushNamed(context, '/admin/users'),
                 ),

--- a/mobile/lib/features/agent/agent_dashboard_screen.dart
+++ b/mobile/lib/features/agent/agent_dashboard_screen.dart
@@ -309,7 +309,8 @@ class _AgentDashboardScreenState extends State<AgentDashboardScreen>
             crossAxisCount: 2,
             crossAxisSpacing: 16,
             mainAxisSpacing: 16,
-            childAspectRatio: 1.3,
+            // Slightly reduce height to avoid small vertical overflows on narrow widths
+            childAspectRatio: 1.25,
             children: [
               _buildStatCard(
                 'Total Properties',


### PR DESCRIPTION
Fix type errors in date parsing and resolve RenderFlex overflow in dashboards.

The `_formatTimeAgo` function was updated to safely handle `createdAt` values that could be `DateTime` objects, ISO8601 strings, or epoch integers, preventing a `_TypeError` when a string was encountered instead of a `DateTime`. Additionally, the `childAspectRatio` in the agent dashboard was slightly reduced to mitigate `RenderFlex overflow` issues.

---
<a href="https://cursor.com/background-agent?bcId=bc-1ff9ad07-fdfd-4370-ad1a-d24b26014ff5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1ff9ad07-fdfd-4370-ad1a-d24b26014ff5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

