### PR TITLE
Fix date type errors and render overflows

### DIFF
--- a/mobile/lib/features/admin/admin_dashboard_screen.dart
+++ b/mobile/lib/features/admin/admin_dashboard_screen.dart
@@ -197,17 +197,44 @@ class _AdminDashboardScreenState extends State<AdminDashboardScreen>
   String _formatTimeAgo(dynamic date) {
     // Accepts DateTime, ISO8601 string, or epoch (ms/seconds)
     DateTime dateTime;
-    if (date is DateTime) {
-      dateTime = date;
-    } else if (date is String) {
-      dateTime = DateTime.tryParse(date) ?? DateTime.now();
-    } else if (date is int) {
-      // Heuristic: treat 13-digit as milliseconds, 10-digit as seconds
-      final isSeconds = date.toString().length <= 10;
-      dateTime = DateTime.fromMillisecondsSinceEpoch(
-        isSeconds ? date * 1000 : date,
-      );
-    } else {
+    try {
+      if (date is DateTime) {
+        dateTime = date;
+      } else if (date is String) {
+        // Handle ISO8601 string or numeric epoch represented as string
+        final numeric = int.tryParse(date);
+        if (numeric != null) {
+          final isSeconds = date.length <= 10;
+          dateTime = DateTime.fromMillisecondsSinceEpoch(
+            isSeconds ? numeric * 1000 : numeric,
+          );
+        } else {
+          dateTime = DateTime.tryParse(date) ?? DateTime.now();
+        }
+      } else if (date is int) {
+        // Heuristic: treat 13-digit as milliseconds, 10-digit as seconds
+        final isSeconds = date.toString().length <= 10;
+        dateTime = DateTime.fromMillisecondsSinceEpoch(
+          isSeconds ? date * 1000 : date,
+        );
+      } else if (date is Map<String, dynamic>) {
+        // Support Firebase-like timestamp { seconds: 123, nanoseconds: ... }
+        if (date['seconds'] is int) {
+          final seconds = date['seconds'] as int;
+          dateTime = DateTime.fromMillisecondsSinceEpoch(seconds * 1000);
+        } else if (date['milliseconds'] is int) {
+          dateTime = DateTime.fromMillisecondsSinceEpoch(date['milliseconds'] as int);
+        } else if (date['ms'] is int) {
+          dateTime = DateTime.fromMillisecondsSinceEpoch(date['ms'] as int);
+        } else if (date['iso'] is String) {
+          dateTime = DateTime.tryParse(date['iso'] as String) ?? DateTime.now();
+        } else {
+          dateTime = DateTime.now();
+        }
+      } else {
+        dateTime = DateTime.now();
+      }
+    } catch (_) {
       dateTime = DateTime.now();
     }
 

--- a/mobile/lib/features/agent/agent_dashboard_screen.dart
+++ b/mobile/lib/features/agent/agent_dashboard_screen.dart
@@ -309,8 +309,8 @@ class _AgentDashboardScreenState extends State<AgentDashboardScreen>
             crossAxisCount: 2,
             crossAxisSpacing: 16,
             mainAxisSpacing: 16,
-            // Slightly reduce height to avoid small vertical overflows on narrow widths
-            childAspectRatio: 1.25,
+            // Increase aspect ratio so each card is slightly shorter, reducing overflow risk
+            childAspectRatio: 1.35,
             children: [
               _buildStatCard(
                 'Total Properties',
@@ -438,6 +438,8 @@ class _AgentDashboardScreenState extends State<AgentDashboardScreen>
                         style: theme.textTheme.bodyMedium?.copyWith(
                           color: theme.colorScheme.onSurfaceVariant,
                         ),
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
                       ),
                       const SizedBox(height: 4),
                       Text(
@@ -446,6 +448,8 @@ class _AgentDashboardScreenState extends State<AgentDashboardScreen>
                           fontWeight: FontWeight.bold,
                           color: color,
                         ),
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
                       ),
                       const SizedBox(height: 4),
                       Text(
@@ -453,6 +457,8 @@ class _AgentDashboardScreenState extends State<AgentDashboardScreen>
                         style: theme.textTheme.bodySmall?.copyWith(
                           color: theme.colorScheme.onSurfaceVariant,
                         ),
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
                       ),
                     ],
                   ),


### PR DESCRIPTION
Refactor `_formatTimeAgo` to handle diverse date formats and resolve `RenderFlex` overflows in the agent dashboard.

The `_TypeError` was caused by `_formatTimeAgo` not correctly parsing various timestamp formats (e.g., numeric strings, map objects) from the backend. The `RenderFlex` overflow in the agent dashboard occurred because stat card content, particularly text, exceeded the available vertical space, especially on narrower screens. This PR makes the date parsing more robust and adjusts the layout to prevent overflows.

---
<a href="https://cursor.com/background-agent?bcId=bc-95a2abea-ec08-41ac-8649-140cca3b494b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-95a2abea-ec08-41ac-8649-140cca3b494b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

