### PR TITLE
Refactor mobile app for web parity and testing

### DIFF
--- a/mobile/lib/screens/subscription_screen.dart
+++ b/mobile/lib/screens/subscription_screen.dart
@@ -238,15 +238,35 @@ class _SubscriptionScreenState extends State<SubscriptionScreen> {
         billingCycle: plan.billingCycle,
       );
 
-      final key = (keyRes.data is Map && keyRes.data['key'] != null) ? keyRes.data['key'].toString() : '';
-      final orderId = (orderRes.data is Map && orderRes.data['orderId'] != null) ? orderRes.data['orderId'].toString() : '';
+      final key = (keyRes.data is Map && keyRes.data['key'] != null)
+          ? keyRes.data['key'].toString()
+          : '';
+
+      // Server responds with { success, order, subscription }
+      // Extract order.id and order.amount (already in paise)
+      String orderId = '';
+      int amountPaise = (plan.price * 100).toInt();
+      if (orderRes.data is Map) {
+        final map = Map<String, dynamic>.from(orderRes.data as Map);
+        final order = map['order'] is Map ? Map<String, dynamic>.from(map['order']) : null;
+        if (order != null) {
+          orderId = order['id']?.toString() ?? '';
+          final dynamic srvAmount = order['amount'];
+          if (srvAmount is int) {
+            amountPaise = srvAmount;
+          } else if (srvAmount is String) {
+            amountPaise = int.tryParse(srvAmount) ?? amountPaise;
+          }
+        }
+      }
+
       if (key.isEmpty || orderId.isEmpty) {
         throw Exception('Failed to initiate payment');
       }
 
       final options = {
         'key': key,
-        'amount': (plan.price * 100).toInt(), // in paise
+        'amount': amountPaise, // in paise, from server
         'currency': 'INR',
         'name': 'Urban Realty',
         'description': 'Subscription: ${plan.name} (${plan.billingCycle})',

--- a/new-migration-report.md
+++ b/new-migration-report.md
@@ -81,6 +81,9 @@ Last updated: 2025-09-04 (mobile: admin settings/reports/media parity; analytics
    - Adds `source: 'mobile'` inside `data`.
    - Validated against `server/src/api/routes/analyticsRoutes.js` which expects `action` and `data`.
 
+ - [Mobile] Razorpay integration fix:
+   - Corrected parsing of Razorpay order response in `mobile/lib/screens/subscription_screen.dart` to use `order.id` and server-provided `order.amount` (paise) instead of expecting `orderId` at root and recomputing amount. This prevents amount/signature mismatches during checkout.
+
 ## Current Work In This Run
 - Admin analytics parity on mobile: dashboard/search/system metrics and CSV export.
 - Admin settings parity on mobile: fetch/save settings, backup and restore actions.


### PR DESCRIPTION
Correct Razorpay order response parsing in the mobile app to use server-provided `order.id` and `amount`.

This change ensures the mobile app correctly extracts the order ID and amount (in paise) from the server's Razorpay order response, preventing potential payment amount or signature mismatches during checkout.

---
<a href="https://cursor.com/background-agent?bcId=bc-dda76cd6-291f-4757-b929-1d45f9119b16">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-dda76cd6-291f-4757-b929-1d45f9119b16">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

