### PR TITLE
Fix rendering errors and locate subscription management

### DIFF
--- a/mobile/lib/features/admin/admin_dashboard_screen.dart
+++ b/mobile/lib/features/admin/admin_dashboard_screen.dart
@@ -567,28 +567,28 @@ class _AdminDashboardScreenState extends State<AdminDashboardScreen>
                     children: [
                       _buildSystemHealthCard(
                         'CPU Usage',
-                        '${stats['analytics']['systemHealth']['cpu']}%',
+                        '${stats['analytics']?['systemHealth']?['cpu'] ?? 0}%',
                         Icons.speed,
                         Colors.blue,
                         theme,
                       ),
                       _buildSystemHealthCard(
                         'Memory',
-                        '${stats['analytics']['systemHealth']['memory']}%',
+                        '${stats['analytics']?['systemHealth']?['memory'] ?? 0}%',
                         Icons.storage,
                         Colors.purple,
                         theme,
                       ),
                       _buildSystemHealthCard(
                         'Storage',
-                        '${stats['analytics']['systemHealth']['storage']}%',
+                        '${stats['analytics']?['systemHealth']?['storage'] ?? 0}%',
                         Icons.storage,
                         Colors.cyan,
                         theme,
                       ),
                       _buildSystemHealthCard(
                         'Network',
-                        '${stats['analytics']['systemHealth']['network']}%',
+                        '${stats['analytics']?['systemHealth']?['network'] ?? 0}%',
                         Icons.network_check,
                         Colors.green,
                         theme,

--- a/mobile/lib/features/agent/agent_dashboard_screen.dart
+++ b/mobile/lib/features/agent/agent_dashboard_screen.dart
@@ -309,8 +309,8 @@ class _AgentDashboardScreenState extends State<AgentDashboardScreen>
             crossAxisCount: 2,
             crossAxisSpacing: 16,
             mainAxisSpacing: 16,
-            // Increase aspect ratio so each card is slightly shorter, reducing overflow risk
-            childAspectRatio: 1.35,
+            // Increase aspect ratio to provide more height for content
+            childAspectRatio: 1.2,
             children: [
               _buildStatCard(
                 'Total Properties',
@@ -441,17 +441,17 @@ class _AgentDashboardScreenState extends State<AgentDashboardScreen>
                         maxLines: 1,
                         overflow: TextOverflow.ellipsis,
                       ),
-                      const SizedBox(height: 4),
+                      const SizedBox(height: 2),
                       Text(
                         value,
-                        style: theme.textTheme.headlineMedium?.copyWith(
+                        style: theme.textTheme.headlineSmall?.copyWith(
                           fontWeight: FontWeight.bold,
                           color: color,
                         ),
                         maxLines: 1,
                         overflow: TextOverflow.ellipsis,
                       ),
-                      const SizedBox(height: 4),
+                      const SizedBox(height: 2),
                       Text(
                         subtitle,
                         style: theme.textTheme.bodySmall?.copyWith(
@@ -469,7 +469,7 @@ class _AgentDashboardScreenState extends State<AgentDashboardScreen>
                 ),
               ],
             ),
-            const SizedBox(height: 8),
+            const SizedBox(height: 4),
             Row(
               children: [
                 Icon(


### PR DESCRIPTION
Fix `NoSuchMethodError` in Admin Dashboard and resolve `RenderFlex` overflow in Agent Dashboard.

The `NoSuchMethodError` was caused by attempting to access properties on a null `systemHealth` object. The `RenderFlex` overflow was due to insufficient space for content within the agent dashboard stat cards.

---
<a href="https://cursor.com/background-agent?bcId=bc-1a8d212c-74e3-47b1-9b98-28cba2731b0a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1a8d212c-74e3-47b1-9b98-28cba2731b0a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

