### PR TITLE
Fix hero and property card rendering errors

### DIFF
--- a/new-nextjs-app/src/app/properties/page.tsx
+++ b/new-nextjs-app/src/app/properties/page.tsx
@@ -54,7 +54,12 @@ const PropertyCard = ({ property }) => {
           <div className="property-spec-divider">|</div>
           <div className="property-spec">{property.baths} Bath</div>
         </div>
-        <div className="property-location">{property.location}</div>
+        <div className="property-location">
+          {typeof property.location === 'object' 
+            ? `${property.location.address || ''}, ${property.location.city || ''}, ${property.location.state || ''}`.replace(/^,\s*|,\s*$/g, '')
+            : property.location
+          }
+        </div>
       </div>
     </div>
   );

--- a/new-nextjs-app/src/components/home/HeroSection.jsx
+++ b/new-nextjs-app/src/components/home/HeroSection.jsx
@@ -76,15 +76,17 @@ const HeroSection = () => {
   const currentCityLocalities = getLocalitiesForCity();
 
   useEffect(() => {
-    const params = Object.fromEntries(searchParams.entries());
-    if (params.search) setSearchText(params.search);
-    if (params.city) {
-      if (availableCities.includes(params.city)) {
-        setSelectedCity(params.city);
+    if (searchParams) {
+      const params = Object.fromEntries(searchParams.entries());
+      if (params.search) setSearchText(params.search);
+      if (params.city) {
+        if (availableCities.includes(params.city)) {
+          setSelectedCity(params.city);
+        }
       }
-    }
-    if (params.propertyType) {
-      setSelectedTab(params.propertyType === 'BUY' ? 'BUY' : params.propertyType === 'RENT' ? 'RENT' : 'ALL');
+      if (params.propertyType) {
+        setSelectedTab(params.propertyType === 'BUY' ? 'BUY' : params.propertyType === 'RENT' ? 'RENT' : 'ALL');
+      }
     }
 
     const updateVisibleCount = () => {


### PR DESCRIPTION
Fix `TypeError` in `HeroSection` by adding a null check for `searchParams` and `Objects are not valid as a React child` in `PropertyCard` by properly formatting the location object.

The `HeroSection` error occurred because `useSearchParams()` could return `undefined` on initial render, leading to a crash when `entries()` was called. The `PropertyCard` error happened because `property.location` was sometimes an object instead of a string, and React cannot render objects directly as children. The fix ensures robust handling of both scenarios.

---
<a href="https://cursor.com/background-agent?bcId=bc-0fa0d91c-b0a2-4a95-a756-c61f72280737">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0fa0d91c-b0a2-4a95-a756-c61f72280737">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

