### PR TITLE
Fix missing keys in property list

### DIFF
--- a/new-nextjs-app/src/app/properties/page.tsx
+++ b/new-nextjs-app/src/app/properties/page.tsx
@@ -32,7 +32,7 @@ const PropertyCard = ({ property }) => {
       onMouseLeave={() => setIsHovered(false)}
     >
       <div className="property-image-container">
-        <img src={property.image} alt={property.location} className="property-image" />
+        <img src={property.images?.[0] || '/placeholder-property.jpg'} alt={property.title} className="property-image" />
         <div className="property-image-overlay">
           <div className="property-image-actions">
             <button className="image-action-btn">
@@ -46,13 +46,13 @@ const PropertyCard = ({ property }) => {
       </div>
 
       <div className="property-details">
-        <div className="property-price">{property.price}</div>
+        <div className="property-price">${property.price?.toLocaleString()}</div>
         <div className="property-specs">
-          <div className="property-spec">{property.sqft}</div>
+          <div className="property-spec">{property.features?.sqft} sqft</div>
           <div className="property-spec-divider">|</div>
-          <div className="property-spec">{property.beds} Bed</div>
+          <div className="property-spec">{property.features?.bedrooms} Bed</div>
           <div className="property-spec-divider">|</div>
-          <div className="property-spec">{property.baths} Bath</div>
+          <div className="property-spec">{property.features?.bathrooms} Bath</div>
         </div>
         <div className="property-location">
           {typeof property.location === 'object' 
@@ -248,7 +248,7 @@ const Properties = () => {
             </div>
           ) : (
             properties.map(property => (
-              <PropertyCard key={property._id} property={property} />
+              <PropertyCard key={property.id} property={property} />
             ))
           )}
         </div>


### PR DESCRIPTION
Update `PropertyCard` key prop to `property.id` and adjust data access to match mock data structure, resolving React 'key' warning.

---
<a href="https://cursor.com/background-agent?bcId=bc-cbf438dc-1bb0-42c3-8c50-5e5ca90c4616">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cbf438dc-1bb0-42c3-8c50-5e5ca90c4616">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

