### PR TITLE
Fix invalid rewrite configuration

### DIFF
--- a/new-nextjs-app/next.config.js
+++ b/new-nextjs-app/next.config.js
@@ -100,10 +100,18 @@ const nextConfig = {
 
   // Rewrites for API proxy
   async rewrites() {
+    const apiUrl = process.env.NEXT_PUBLIC_API_URL;
+    
+    // Only add rewrite if API URL is defined
+    if (!apiUrl) {
+      console.warn('NEXT_PUBLIC_API_URL is not defined. API rewrites will be skipped.');
+      return [];
+    }
+    
     return [
       {
         source: '/api/:path*',
-        destination: `${process.env.NEXT_PUBLIC_API_URL}/:path*`,
+        destination: `${apiUrl}/:path*`,
       },
     ];
   },


### PR DESCRIPTION
Conditionally add API rewrites in `next.config.js` to prevent `Invalid rewrite found` errors when `NEXT_PUBLIC_API_URL` is not set.

---
<a href="https://cursor.com/background-agent?bcId=bc-4abd2ea4-d998-4d5b-9858-abf752c0dbc2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4abd2ea4-d998-4d5b-9858-abf752c0dbc2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

