### PR TITLE
Fix api error import in error handler

### DIFF
--- a/new-nextjs-app/src/lib/services/apiService.ts
+++ b/new-nextjs-app/src/lib/services/apiService.ts
@@ -581,5 +581,6 @@ export const apiService = new ApiService();
 // Export for use in components
 export default apiService;
 
-// Export types
-export type { ApiResponse, ApiError };
+// Export types and classes
+export type { ApiResponse };
+export { ApiError };


### PR DESCRIPTION
Correctly export `ApiError` as a class to resolve import errors in `errorHandler.tsx`.

---
<a href="https://cursor.com/background-agent?bcId=bc-79bdaf5d-1230-417b-ad24-4a23b42b835a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-79bdaf5d-1230-417b-ad24-4a23b42b835a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

