### PR TITLE
Fix api json parse error on property pages

### DIFF
--- a/new-nextjs-app/src/lib/services/apiService.ts
+++ b/new-nextjs-app/src/lib/services/apiService.ts
@@ -79,7 +79,35 @@ class HttpClient {
 
     try {
       const response = await fetch(url, config);
-      const data = await response.json();
+      // Safely parse response: handle empty bodies and non-JSON
+      let data: any = null;
+      const contentType = response.headers.get('content-type') || '';
+      const contentLength = response.headers.get('content-length');
+
+      // 204 No Content or explicitly empty body
+      if (response.status === 204 || contentLength === '0') {
+        data = null;
+      } else if (contentType.includes('application/json')) {
+        try {
+          data = await response.json();
+        } catch (parseErr) {
+          // Fallback to text for mislabelled responses
+          const text = await response.text();
+          throw new ApiError(
+            'Invalid JSON response',
+            response.status,
+            { body: text }
+          );
+        }
+      } else {
+        // Not JSON; read as text and throw a helpful error for callers
+        const text = await response.text();
+        throw new ApiError(
+          'Unexpected non-JSON response',
+          response.status,
+          { body: text, contentType }
+        );
+      }
 
       if (!response.ok) {
         throw new ApiError(
@@ -93,10 +121,10 @@ class HttpClient {
       // callers can always read response.data as the actual payload object/array
       // (and not the envelope). Previously, the spread overwrote data.
       return {
-        ...data,
+        ...(data && typeof data === 'object' ? data : {}),
         status: response.status,
-        success: data.success !== false,
-        data: (data && typeof data === 'object' && 'data' in data) ? data.data : data,
+        success: data && typeof data === 'object' && 'success' in data ? data.success !== false : true,
+        data: (data && typeof data === 'object' && 'data' in data) ? (data as any).data : data,
       };
     } catch (error) {
       if (error instanceof ApiError) {


### PR DESCRIPTION
Improve API client robustness to handle non-JSON and empty responses, resolving `JSON.parse` errors and enabling real data display.

The previous API client would attempt to parse all responses as JSON, leading to `JSON.parse: unexpected character` errors when the backend returned non-JSON content (e.g., HTML error pages, or 204 No Content responses). This prevented the application from correctly processing API responses, causing UI components to either crash or fall back to displaying mock data.

---
<a href="https://cursor.com/background-agent?bcId=bc-c17b4a67-066a-4adf-8e0f-4d29b81fd0f3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c17b4a67-066a-4adf-8e0f-4d29b81fd0f3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

