### PR TITLE
Update report with refactoring changes

### DIFF
--- a/new-nextjs-app/report23.md
+++ b/new-nextjs-app/report23.md
@@ -117,6 +117,27 @@ This report tracks the implementation of the refactoring plan outlined in `REFAC
 - Audit mapping: Phase 0 — Baseline/type safety; Phase 3 — Centralized error shape.
 - Notes/Risks: Backward compatible with errors carrying `status`.
 
+### Change ID: 44
+- Files affected: `src/components/home/AccountSidebar.jsx`
+- Summary: Replaced `apiService.getRecentlyViewed()` with centralized `api.auth.recentlyViewedList()` and simplified data normalization.
+- Rationale: Remove remaining `apiService` usage and align with centralized API per audit.
+- Audit mapping: Phase 3 — API centralization and React Query integration.
+- Notes/Risks: None.
+
+### Change ID: 45
+- Files affected: `src/components/admin/SubscriptionManagement.jsx`
+- Summary: Switched data fetching from `apiService.getSubscriptionPlans()` and `getUserSubscription()` to centralized `api.subscriptions.plans()` and `api.subscriptions.current()`. Updated state assignments to use normalized responses.
+- Rationale: Continue removal of legacy `apiService` in admin flows; align with centralized API.
+- Audit mapping: Phase 3 — API centralization and React Query integration.
+- Notes/Risks: The create/delete plan actions remain mocked; future enhancement to wire mutations.
+
+### Change ID: 46
+- Files affected: `src/components/admin/AnalyticsDashboard.jsx`
+- Summary: Replaced `apiService.getAdminAnalytics()` with `api.admin.analytics()` and adapted to normalized response shape.
+- Rationale: Standardize analytics fetch on centralized API and remove legacy service.
+- Audit mapping: Phase 3 — API centralization and React Query integration.
+- Notes/Risks: Local mock sections for search/system remain.
+
 ## Issues and Blockers
 - None currently identified
 

--- a/new-nextjs-app/src/components/admin/AnalyticsDashboard.jsx
+++ b/new-nextjs-app/src/components/admin/AnalyticsDashboard.jsx
@@ -33,7 +33,7 @@ import {
   Download,
   Refresh
 } from '@mui/icons-material';
-import apiService from '@/lib/services/apiService';
+import { api } from '@/lib/services/api';
 
 const AnalyticsDashboard = () => {
   const [analytics, setAnalytics] = useState(null);
@@ -43,12 +43,12 @@ const AnalyticsDashboard = () => {
   const fetchAnalytics = async () => {
     try {
       setLoading(true);
-      const [dashboard] = await Promise.all([
-        apiService.getAdminAnalytics(),
+      const [dashboardRes] = await Promise.all([
+        api.admin.analytics(),
       ]);
       
       setAnalytics({
-        dashboard: dashboard,
+        dashboard: dashboardRes?.data,
         search: {
           totalSearches: 1250,
           uniqueUsers: 450,

--- a/new-nextjs-app/src/components/admin/SubscriptionManagement.jsx
+++ b/new-nextjs-app/src/components/admin/SubscriptionManagement.jsx
@@ -43,7 +43,7 @@ import {
   Warning as WarningIcon,
   TrendingUp as TrendingUpIcon
 } from '@mui/icons-material';
-import apiService from '@/lib/services/apiService';
+import { api } from '@/lib/services/api';
 
 const SubscriptionManagement = () => {
   const [activeTab, setActiveTab] = useState(0);
@@ -82,12 +82,12 @@ const SubscriptionManagement = () => {
     try {
       setLoading(true);
       const [plansRes, subscriptionsRes] = await Promise.all([
-        apiService.getSubscriptionPlans(),
-        apiService.getUserSubscription('user1')
+        api.subscriptions.plans(),
+        api.subscriptions.current('user1')
       ]);
-      
-      setPlans(plansRes.data || []);
-      setSubscriptions(subscriptionsRes.data ? [subscriptionsRes.data] : []);
+
+      setPlans(plansRes?.data || []);
+      setSubscriptions(subscriptionsRes?.data ? [subscriptionsRes.data] : []);
     } catch (err) {
       console.error('Error fetching data:', err);
       setError('Failed to load data');

--- a/new-nextjs-app/src/components/home/AccountSidebar.jsx
+++ b/new-nextjs-app/src/components/home/AccountSidebar.jsx
@@ -14,7 +14,7 @@ import { useAuth } from '@/contexts/AuthContext';
 import { useProperties } from '@/contexts/PropertiesContext';
 import { useRouter } from 'next/navigation';
 import { motion, AnimatePresence } from "framer-motion";
-import apiService from '@/lib/services/apiService';
+import { api } from '@/lib/services/api';
 
 const AccountSidebar = ({ isOpen, onClose }) => {
   const { user, logout } = useAuth();
@@ -107,9 +107,8 @@ const AccountSidebar = ({ isOpen, onClose }) => {
     const loadRecentlyViewed = async () => {
       if (!user) return setRecentlyViewed([]);
       try {
-        const res = await apiService.getRecentlyViewed();
-        const items = Array.isArray(res?.data?.data) ? res.data.data : (res?.data || []);
-        setRecentlyViewed(items);
+        const res = await api.auth.recentlyViewedList();
+        setRecentlyViewed(Array.isArray(res?.data) ? res.data : []);
       } catch (e) {
         setRecentlyViewed([]);
       }

--- a/report23.md
+++ b/report23.md
@@ -310,3 +310,24 @@ Change ID: 38
 - Rationale: Type hardening and SSR-safe routing; aligns with centralized HTTP client usage and removes legacy window dependency during navigation.
 - Audit mapping: Phase 1 — Routing hygiene (SSR/window guards); Phase 2 — Component extraction/cleanup; Phase 4 — Type hardening.
 - Notes/Risks: Downstream imports without extension will now resolve to TSX. Verified references in `PropertiesSection.jsx` and `app/user/profile/page.tsx` target the folder and will pick up the TSX version.
+
+Change ID: 44
+- Files affected: `new-nextjs-app/src/components/home/AccountSidebar.jsx`
+- Summary: Replaced `apiService.getRecentlyViewed()` with centralized `api.auth.recentlyViewedList()` and simplified data normalization.
+- Rationale: Remove remaining `apiService` usage and align with centralized API per audit.
+- Audit mapping: Phase 3 — API centralization and React Query integration.
+- Notes/Risks: None.
+
+Change ID: 45
+- Files affected: `new-nextjs-app/src/components/admin/SubscriptionManagement.jsx`
+- Summary: Switched data fetching from `apiService.getSubscriptionPlans()` and `getUserSubscription()` to centralized `api.subscriptions.plans()` and `api.subscriptions.current()`. Updated state assignments to use normalized responses.
+- Rationale: Continue removal of legacy `apiService` in admin flows; align with centralized API.
+- Audit mapping: Phase 3 — API centralization and React Query integration.
+- Notes/Risks: Create/delete plan actions still mocked; to be wired later.
+
+Change ID: 46
+- Files affected: `new-nextjs-app/src/components/admin/AnalyticsDashboard.jsx`
+- Summary: Replaced `apiService.getAdminAnalytics()` with `api.admin.analytics()` and adapted to normalized response shape.
+- Rationale: Standardize analytics fetch on centralized API and remove legacy service.
+- Audit mapping: Phase 3 — API centralization and React Query integration.
+- Notes/Risks: Local mock sections for search/system remain.


### PR DESCRIPTION
Migrate `AccountSidebar`, `SubscriptionManagement`, and `AnalyticsDashboard` to the centralized API to remove legacy `apiService` usage per the refactoring audit.

---
<a href="https://cursor.com/background-agent?bcId=bc-6d72a56a-2073-44a6-9cc6-3b50e7985ca8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6d72a56a-2073-44a6-9cc6-3b50e7985ca8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

