### PR TITLE
Fix razorpay checkout otp error

### DIFF
--- a/new-nextjs-app/middleware.ts
+++ b/new-nextjs-app/middleware.ts
@@ -23,7 +23,8 @@ export function middleware(request: NextRequest) {
   const createResponse = (response: NextResponse) => {
     // Add payment-specific headers for subscription pages
     if (isSubscriptionPath) {
-      response.headers.set('Permissions-Policy', 'payment=*, otp-credentials=*')
+      // Remove unsupported otp-credentials directive to avoid console warnings
+      response.headers.set('Permissions-Policy', 'payment=(self)')
       response.headers.set('X-Frame-Options', 'SAMEORIGIN')
     }
     return response

--- a/new-nextjs-app/src/hooks/api/subscriptions.ts
+++ b/new-nextjs-app/src/hooks/api/subscriptions.ts
@@ -39,7 +39,7 @@ export function useRazorpayKey(options?: UseQueryOptions<any, Error, any, readon
         queryKey: queryKeys.razorpayKey,
         queryFn: async () => {
             const res = await api.subscriptions.razorpayKey();
-            return res;
+            return res.data;
         },
         staleTime: 10 * 60 * 1000, // 10 minutes
         ...options,
@@ -50,7 +50,7 @@ export function useCreateRazorpayOrderMutation(options?: UseMutationOptions<any,
     return useMutation({
         mutationFn: async ({ subscriptionId, billingCycle }) => {
             const res = await api.subscriptions.createRazorpayOrder({ subscriptionId, billingCycle });
-            return res;
+            return res.data;
         },
         ...options,
     });
@@ -62,7 +62,7 @@ export function useVerifyRazorpayPaymentMutation(options?: UseMutationOptions<an
     return useMutation({
         mutationFn: async (paymentData) => {
             const res = await api.subscriptions.verifyRazorpayPayment(paymentData);
-            return res;
+            return res.data;
         },
         onSuccess: () => {
             // Invalidate subscription queries to refresh the data


### PR DESCRIPTION
Remove `otp-credentials` from `Permissions-Policy` and fix Razorpay hooks to return `res.data` to resolve console warnings and payment configuration errors.

The `otp-credentials` directive is not a standard `Permissions-Policy` feature, causing console warnings. Additionally, the Razorpay hooks were returning the entire API response object instead of the specific `data` property, which meant the UI could not correctly access the `key` and `order` necessary for the payment flow, resulting in a "Payment system configuration error".

---
<a href="https://cursor.com/background-agent?bcId=bc-566e83ad-cebe-4c9d-bd30-b9fafab9fd84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-566e83ad-cebe-4c9d-bd30-b9fafab9fd84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

