### PR TITLE
Fix razorpay otp credentials error

### DIFF
--- a/new-nextjs-app/next.config.js
+++ b/new-nextjs-app/next.config.js
@@ -86,8 +86,7 @@ const nextConfig = {
               'microphone=()',
               'geolocation=()',
               'interest-cohort=()',
-              'payment=*', // Allow payment API for all origins
-              'otp-credentials=*' // Allow OTP credentials for payment flows
+              'payment=(self)' // Allow Payment Request API only for this origin
             ].join(', '),
           },
         ],

--- a/new-nextjs-app/src/app/layout.tsx
+++ b/new-nextjs-app/src/app/layout.tsx
@@ -12,7 +12,8 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     <html lang="en">
       <head>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <meta httpEquiv="Permissions-Policy" content="payment=*, otp-credentials=*" />
+        {/* Restrict to supported directives only */}
+        <meta httpEquiv="Permissions-Policy" content="payment=(self)" />
         <meta httpEquiv="Content-Security-Policy" content="script-src 'self' 'unsafe-inline' 'unsafe-eval' https://checkout.razorpay.com; connect-src 'self' http://localhost:3001 https://api.razorpay.com https://checkout.razorpay.com; frame-src 'self' https://api.razorpay.com https://checkout.razorpay.com;" />
       </head>
       <body>

--- a/new-nextjs-app/src/components/Subscription/RazorpayPaymentForm.tsx
+++ b/new-nextjs-app/src/components/Subscription/RazorpayPaymentForm.tsx
@@ -61,16 +61,6 @@ const RazorpayPaymentForm: React.FC<RazorpayPaymentFormProps> = ({
   const verifyPaymentMutation = useVerifyRazorpayPaymentMutation();
 
   useEffect(() => {
-    // Suppress OTP credentials warning in console
-    const originalConsoleError = console.error;
-    console.error = (...args) => {
-      if (typeof args[0] === 'string' && args[0].includes('otp-credentials')) {
-        // Silently ignore otp-credentials warnings
-        return;
-      }
-      originalConsoleError.apply(console, args);
-    };
-
     // Load Razorpay script
     if (!window.Razorpay) {
       const script = document.createElement('script');
@@ -87,10 +77,8 @@ const RazorpayPaymentForm: React.FC<RazorpayPaymentFormProps> = ({
       setRazorpayLoaded(true);
     }
 
-    // Cleanup function to restore console.error
-    return () => {
-      console.error = originalConsoleError;
-    };
+    // No cleanup needed
+    return () => {};
   }, []);
 
   const getTotalPrice = () => {


### PR DESCRIPTION
Remove unrecognized 'otp-credentials' feature from Permissions-Policy and restrict 'payment' to self to fix console errors and payment initiation issues.

The `otp-credentials` directive is not a standard or widely supported Permissions-Policy feature, leading to "Unrecognized feature" console errors. This PR updates the Permissions-Policy to only include the `payment=(self)` directive, which is supported and more secure, resolving the console warnings and potential underlying issues affecting payment initiation. The console error suppression for `otp-credentials` is also removed as it's no longer necessary.

---
<a href="https://cursor.com/background-agent?bcId=bc-b317163c-fff8-4d7c-a0ad-65d79dc44354"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b317163c-fff8-4d7c-a0ad-65d79dc44354"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

