### PR TITLE
Fix favorite removal API call logic

### DIFF
--- a/new-nextjs-app/src/app/properties/[id]/page.tsx
+++ b/new-nextjs-app/src/app/properties/[id]/page.tsx
@@ -102,12 +102,16 @@ const PropertyDetails = () => {
     try {
       // Ensure id is a string (handle case where it might be an array)
       const propertyId = Array.isArray(id) ? id[0] : id;
-      // Use toggle endpoint and update state from response
-      const res = await api.auth.addFavorite(propertyId as string);
+      const res = await api.auth.toggleFavorite(propertyId as string, !isFavorite);
       const toggled = Boolean((res as any)?.data?.isFavorite ?? !isFavorite);
       setIsFavorite(toggled);
     } catch (err) {
       console.error('Error toggling favorite:', err);
+      try {
+        const propertyId = Array.isArray(id) ? id[0] : id;
+        const status = await api.auth.favoriteStatus(propertyId as string);
+        setIsFavorite(Boolean((status as any)?.data?.isFavorite));
+      } catch (_) {}
     }
   };
 

--- a/new-nextjs-app/src/components/ui/PropertyCard.tsx
+++ b/new-nextjs-app/src/components/ui/PropertyCard.tsx
@@ -152,9 +152,9 @@ const PropertyCardContent: React.FC<Omit<PropertyCardProps, 'lazy'>> = ({
 
     setLoadingFavorite(true);
     try {
-      // Use the toggle favorite endpoint which handles both add and remove
-      const response = await api.auth.addFavorite(property._id);
-      const newFavoriteStatus = Boolean(response.data?.isFavorite);
+      const response = await api.auth.toggleFavorite(property._id, !isFavorite);
+      // Prefer server-provided state, fallback to local toggle
+      const newFavoriteStatus = Boolean(response.data?.isFavorite ?? !isFavorite);
       
       setIsFavorite(newFavoriteStatus);
       onFavoriteToggle?.(property, newFavoriteStatus);
@@ -164,6 +164,11 @@ const PropertyCardContent: React.FC<Omit<PropertyCardProps, 'lazy'>> = ({
       toast.success(message);
     } catch (err: any) {
       console.error('Error updating favorite:', err);
+      try {
+        const status = await api.auth.favoriteStatus(property._id);
+        const serverState = Boolean(status.data?.isFavorite);
+        setIsFavorite(serverState);
+      } catch (_) {}
       toast.error(err?.message || 'Failed to update favorites');
     } finally {
       setLoadingFavorite(false);

--- a/new-nextjs-app/src/lib/services/api.ts
+++ b/new-nextjs-app/src/lib/services/api.ts
@@ -30,10 +30,33 @@ export const api = {
                 register: (payload: { name: string; email: string; password: string }) => unwrap<{ user: any }>(http.post("/auth/register", payload)),
                 profile: () => unwrap<any>(http.get("/auth/me")),
                 // Favorites
-                favoritesList: () => unwrap<any[]>(http.get("/auth/favorites")),
-                addFavorite: (propertyId: string) => unwrap<any>(http.put(`/auth/favorites/${propertyId}`, {})),
-                removeFavorite: (propertyId: string) => unwrap<any>(http.delete(`/auth/favorites/${propertyId}`)),
-                favoriteStatus: (propertyId: string) => unwrap<{ isFavorite: boolean }>(http.get(`/auth/favorites/${propertyId}/status`)), 
+				favoritesList: () => unwrap<any[]>(http.get("/auth/favorites")),
+				addFavorite: (propertyId: string) => unwrap<any>(http.put(`/auth/favorites/${propertyId}`, {})),
+				removeFavorite: (propertyId: string) => unwrap<any>(http.delete(`/auth/favorites/${propertyId}`)),
+				favoriteStatus: (propertyId: string) => unwrap<{ isFavorite: boolean }>(http.get(`/auth/favorites/${propertyId}/status`)), 
+				/**
+				 * Toggle favorite state safely. If desiredState is provided, it enforces that state.
+				 * If not provided, it tries PUT first and on 400 falls back to DELETE.
+				 */
+				toggleFavorite: async (propertyId: string, desiredState?: boolean) => {
+					try {
+						if (desiredState === true) {
+							return await api.auth.addFavorite(propertyId);
+						}
+						if (desiredState === false) {
+							return await api.auth.removeFavorite(propertyId);
+						}
+						// Unknown state: attempt PUT as default, then fallback to DELETE on 400
+						const res = await api.auth.addFavorite(propertyId);
+						return res;
+					} catch (err: any) {
+						// If server returns 400 for duplicate add, try DELETE as fallback
+						if (err?.statusCode === 400 || err?.options?.statusCode === 400) {
+							return await api.auth.removeFavorite(propertyId);
+						}
+						throw err;
+					}
+				},
                 // Recently viewed
                 recentlyViewedList: () => unwrap<any[]>(http.get("/auth/recently-viewed")),
                 addRecentlyViewed: (propertyId: string) => unwrap<any>(http.post(`/auth/recently-viewed/${propertyId}`, {})),


### PR DESCRIPTION
Fix 400 Bad Request error when toggling favorites by implementing dynamic PUT/DELETE logic and adding error handling.

The previous implementation always used PUT, leading to a 400 error when trying to remove an already favorited item. This PR introduces a `toggleFavorite` API helper that intelligently uses PUT to add and DELETE to remove. It also includes a fallback mechanism to re-fetch the favorite status from the server if an API call fails, ensuring UI consistency.

---
<a href="https://cursor.com/background-agent?bcId=bc-f3d376dd-90b3-4dc7-952e-d9758c3ae22f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f3d376dd-90b3-4dc7-952e-d9758c3ae22f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

