### PR TITLE
Fix husky not found error during build

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -9,8 +9,7 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "test": "vitest run --reporter=dot",
-    "test:watch": "vitest",
-    "prepare": "husky"
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@emotion/react": "^11.14.0",
@@ -29,7 +28,6 @@
     "date-fns": "^4.1.0",
     "formik": "^2.4.6",
     "framer-motion": "^12.23.12",
-    "husky": "^9.1.7",
     "leaflet": "^1.9.4",
     "lodash": "^4.17.21",
     "node-geocoder": "^4.4.1",
@@ -64,6 +62,7 @@
     "eslint-plugin-react-hooks": "^5.1.0",
     "eslint-plugin-react-refresh": "^0.4.19",
     "globals": "^15.15.0",
+    "husky": "^9.1.7",
     "jsdom": "^26.1.0",
     "postcss": "^8.4.31",
     "tailwindcss": "^3.3.3",

--- a/package.json
+++ b/package.json
@@ -11,8 +11,7 @@
     "dev": "concurrently \"npm run server\" \"npm run client\"",
     "install-all": "npm install && cd new-nextjs-app && npm install",
     "test": "cd new-nextjs-app && npm run test",
-    "heroku-postbuild": "cd new-nextjs-app && npm install && npm run build",
-    "prepare": "husky"
+    "heroku-postbuild": "cd new-nextjs-app && npm install && npm run build"
   },
   "dependencies": {
     "@fortawesome/free-regular-svg-icons": "^6.7.2",


### PR DESCRIPTION
Remove `prepare` scripts and move `husky` to `devDependencies` to fix `sh: husky: not found` error during Docker builds.

The `prepare` script, which runs `husky`, was causing build failures in production environments because `husky` is a development dependency and was not available when `npm ci --only=production` was executed.

---
<a href="https://cursor.com/background-agent?bcId=bc-9d078881-41b4-4c50-b82f-1c221c147353"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9d078881-41b4-4c50-b82f-1c221c147353"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

