### PR TITLE
Fix nextjs build module not found errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,8 +27,24 @@ COPY package.json package-lock.json* ./
 COPY --from=deps /app/new-nextjs-app/node_modules ./new-nextjs-app/node_modules
 COPY new-nextjs-app/package.json new-nextjs-app/package-lock.json* ./new-nextjs-app/
 
-# Copy all source code
-COPY . .
+# Copy Next.js source code
+COPY new-nextjs-app/src ./new-nextjs-app/src
+COPY new-nextjs-app/public ./new-nextjs-app/public
+COPY new-nextjs-app/next.config.js ./new-nextjs-app/
+COPY new-nextjs-app/next-env.d.ts ./new-nextjs-app/
+COPY new-nextjs-app/tailwind.config.js ./new-nextjs-app/
+COPY new-nextjs-app/postcss.config.cjs ./new-nextjs-app/
+COPY new-nextjs-app/tsconfig.json ./new-nextjs-app/
+COPY new-nextjs-app/middleware.ts ./new-nextjs-app/
+COPY new-nextjs-app/eslint.config.js ./new-nextjs-app/
+COPY new-nextjs-app/vitest.config.ts ./new-nextjs-app/
+COPY new-nextjs-app/vitest.setup.ts ./new-nextjs-app/
+COPY new-nextjs-app/setupTests.ts ./new-nextjs-app/
+
+# Copy backend files
+COPY server ./server
+COPY shared ./shared
+COPY uploads ./uploads
 
 # Build the Next.js application
 WORKDIR /app/new-nextjs-app


### PR DESCRIPTION
Explicitly copy Next.js and backend files in the Dockerfile to resolve "Module not found" errors during the build process.

The previous `COPY . .` command incorrectly placed the Next.js application's source files, causing the build to fail on Railway. This change ensures all necessary files are copied to their expected locations within the Docker image.

---
<a href="https://cursor.com/background-agent?bcId=bc-c10481fe-5326-4a53-a4b9-c1249d0e7b64"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c10481fe-5326-4a53-a4b9-c1249d0e7b64"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

