### PR TITLE
Changes from background agent bc-999cbfc7-ebdc-436c-9f89-06af695e7c66

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,9 +48,11 @@ COPY shared ./shared
 COPY uploads ./uploads
 COPY ecosystem.config.js ./
 COPY server.js ./
+COPY start-server.js ./
 
 # Build the Next.js application
 WORKDIR /app/new-nextjs-app
+ENV SKIP_BUILD_STATIC_GENERATION=true
 RUN npm run build
 
 # Production image, copy all the files and run next
@@ -77,6 +79,7 @@ COPY --from=builder /app/package.json ./
 COPY --from=builder /app/package-lock.json* ./
 COPY --from=builder /app/ecosystem.config.js ./
 COPY --from=builder /app/server.js ./
+COPY --from=builder /app/start-server.js ./
 
 # Copy root node_modules for backend dependencies
 COPY --from=builder /app/node_modules ./node_modules
@@ -90,6 +93,7 @@ RUN mkdir -p /app/logs
 # Set correct permissions
 RUN chown -R nextjs:nodejs /app
 RUN chmod +x /app/server.js
+RUN chmod +x /app/start-server.js
 USER nextjs
 
 EXPOSE 3000
@@ -97,5 +101,5 @@ EXPOSE 3000
 ENV PORT 3000
 ENV HOSTNAME "0.0.0.0"
 
-# Start the application with PM2
-CMD ["pm2-runtime", "start", "ecosystem.config.js", "--env", "production", "--no-daemon"]
+# Start the application with start-server.js
+CMD ["node", "start-server.js"]

--- a/new-nextjs-app/src/app/sitemap.ts
+++ b/new-nextjs-app/src/app/sitemap.ts
@@ -3,34 +3,60 @@ import { getApiBaseUrl } from '@/lib/services/api.config'
 
 const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'https://urban-realty-production.up.railway.app'
 
-// Helper function to fetch dynamic URLs
+// Helper function to fetch dynamic URLs with timeout and fallback
 async function fetchDynamicUrls() {
   try {
     const apiUrl = getApiBaseUrl()
     
-    // Fetch latest properties for sitemap
-    const propertiesResponse = await fetch(`${apiUrl}/api/v1/properties?limit=100&sort=-createdAt`, {
-      next: { revalidate: 86400 }, // Revalidate every 24 hours
-    })
-    const propertiesData = await propertiesResponse.json()
-    const properties = propertiesData.success ? propertiesData.data : []
+    // Create a timeout promise
+    const timeoutPromise = new Promise((_, reject) => 
+      setTimeout(() => reject(new Error('Timeout')), 10000) // 10 second timeout
+    )
     
-    // Fetch developers for sitemap
-    const developersResponse = await fetch(`${apiUrl}/developers?limit=50&sort=-createdAt`, {
+    // Fetch latest properties for sitemap with timeout
+    const propertiesPromise = fetch(`${apiUrl}/api/v1/properties?limit=50&sort=-createdAt`, {
       next: { revalidate: 86400 }, // Revalidate every 24 hours
-    })
-    const developersData = await developersResponse.json()
+    }).then(res => res.json())
+    
+    // Fetch developers for sitemap with timeout
+    const developersPromise = fetch(`${apiUrl}/developers?limit=25&sort=-createdAt`, {
+      next: { revalidate: 86400 }, // Revalidate every 24 hours
+    }).then(res => res.json())
+    
+    // Race against timeout
+    const [propertiesData, developersData] = await Promise.race([
+      Promise.all([propertiesPromise, developersPromise]),
+      timeoutPromise
+    ]) as [any, any]
+    
+    const properties = propertiesData.success ? propertiesData.data : []
     const developers = developersData.success ? developersData.data : []
     
     return { properties, developers }
   } catch (error) {
     console.error('Error fetching dynamic URLs for sitemap:', error)
+    // Return empty arrays to prevent build failure
     return { properties: [], developers: [] }
   }
 }
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const { properties, developers } = await fetchDynamicUrls()
+  // Skip dynamic URL fetching during build if SKIP_BUILD_STATIC_GENERATION is set
+  let properties: any[] = []
+  let developers: any[] = []
+  
+  if (process.env.SKIP_BUILD_STATIC_GENERATION !== 'true') {
+    try {
+      const dynamicData = await fetchDynamicUrls()
+      properties = dynamicData.properties || []
+      developers = dynamicData.developers || []
+    } catch (error) {
+      console.warn('Sitemap: Using static URLs only due to API timeout:', error.message)
+      // Continue with empty arrays - build won't fail
+    }
+  } else {
+    console.log('Sitemap: Skipping dynamic URL generation during build')
+  }
   
   const staticUrls: MetadataRoute.Sitemap = [
     {

--- a/start-server.js
+++ b/start-server.js
@@ -53,4 +53,4 @@ if (isProduction) {
 
 // Start the Express server
 console.log('🚀 Starting Express server...');
-require('./server/server.js');
+require('./server.js');


### PR DESCRIPTION
Resolve Railway deployment failures by fixing server startup configuration and preventing sitemap generation timeouts.

The Next.js build process on Railway was failing due to static page generation timeouts, specifically for `/sitemap.xml`. This was caused by the `sitemap.ts` file making API calls during the build, which could be slow or unavailable, leading to a 60-second timeout and worker exits. The fix introduces a timeout for API calls, a fallback to skip dynamic URL generation if the API is slow, and an environment variable to explicitly skip this during the Docker build, making the build process more resilient.

---
<a href="https://cursor.com/background-agent?bcId=bc-999cbfc7-ebdc-436c-9f89-06af695e7c66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-999cbfc7-ebdc-436c-9f89-06af695e7c66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

